### PR TITLE
docs: reposition README around provenance-first identity (+ roadmap, hero diagram)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,63 @@
 # jurisd
 
-A command-line, terminal-user-interface and MCP-server Australian & NZ legal research tool, built
-**local-first**. jurisd gives an AI assistant a fast, offline-capable recall
-layer over installed legal data modules — deterministic provision lookup,
-local semantic search, and a citation graph — and falls back to live AustLII
-search and an Open Australian Legal Corpus (OALC) layer when the answer is not
-in a local module.
+**Source-grounded Australian & New Zealand legal research, on your own machine.**
 
-The design tenet is **degrade visibly, never silently**: a missing optional
-dependency, an absent API key, or an uninstalled module disables only the
-feature that needs it and is reported back, never swallowed. With no key and no
-network, the local-module recall path still answers.
+jurisd is an open, local-first research and drafting workbench for AU/NZ law. It
+gives you, or the AI assistant you already use, fast answers from legislation and
+case law where **every claim traces back to the primary source**. It runs locally
+by default, so confidential and privileged work never has to leave your machine.
 
-**Status:** pre-1.0, day-0 release candidate. 12 MCP tools across live research,
-citation/bibliography, and local data modules.
+![Your question goes to jurisd on your own machine, which retrieves from Australian and New Zealand primary law and returns an answer with a verifiable citation to the primary source.](docs/diagrams/provenance-loop.svg)
 
-## What jurisd is
+Guiding principle: **no source span, no trusted legal claim.** Vector recall is
+recall, not authority; a model's output is a candidate until you can see its
+source and check it.
 
-jurisd answers Australian (and New Zealand) legal-research questions from an AI
-assistant. It has three answer sources, tried in precedence order:
+> _Previously published as `auslaw-mcp`._
 
-1. **Local data modules (Layer 1)** — installed parquet bundles holding
-   legislation and decisions with provision-level structure, citation edges, and
-   chunk embeddings. Answered offline, no network, no key. This is the
-   **local-first** core: deterministic provision lookup, an Act containment tree,
-   an offline citation graph, and local semantic search.
-2. **Live AustLII (Layer 2)** — natural-language case and legislation search over
-   AustLII, with authority-based ranking, paragraph-pinpoint extraction, full-text
-   fetch (HTML + PDF), and AGLC4 citation formatting.
-3. **OALC fallback (Layer 3)** — an Open Australian Legal Corpus layer that backs
-   the live layer when a direct fetch is blocked.
+**Status:** v0.5.0, pre-1.0. The surface that ships today is a CLI, a TUI search
+shell, and a set of tools the AI assistant you already run can call, across live
+research, citation and bibliography work, and local data modules. The longer arc
+is in [Where this is heading](#where-this-is-heading).
+
+## Why jurisd is different
+
+- **Traceable, not hallucinated.** Every result links to its primary source (an
+  `austlii.edu.au` URL, the provision text, an AGLC4 citation). You verify it; you
+  do not take its word.
+- **Local-first and private.** Recall, provision lookup, and the citation graph
+  work offline over installed corpora. Your matter stays on your machine.
+- **Australian-law-native.** All AU/NZ jurisdictions, jurisdiction-aware search,
+  AGLC4 citation formatting.
+- **Degrades visibly, never silently.** A missing key, dependency, or module
+  disables only the feature that needs it and says so. With no key and no network,
+  local-module recall still answers.
+
+## Who it's for
+
+- The **practitioner** who just wants to ask a question and get an answer they can
+  stand behind in front of a client or a court.
+- The **researcher or student** who needs to trace authority, not just read a
+  summary.
+- The **terminal-native power user** who wants scriptable, composable legal tools.
+- The **builder** wiring AU/NZ legal research into their own AI agent.
+
+## How jurisd answers
+
+jurisd has three answer sources, tried in precedence order:
+
+1. **Local data modules** (offline, no network, no key). Installed parquet bundles
+   holding legislation and decisions with provision-level structure, citation
+   edges, and chunk embeddings. This is the local-first core: deterministic
+   provision lookup, an Act containment tree, an offline citation graph, and local
+   semantic search.
+2. **Live research over AustLII.** Natural-language case and legislation search,
+   full-text fetch (HTML and PDF), and AGLC4 formatting. AustLII's own search sits
+   behind a Cloudflare challenge, so discovery is recovered through Exa-backed
+   search (and direct citation URLs); the documents returned are AustLII primary
+   sources throughout. See [Tools](#tools) for the detail.
+3. **OALC fallback.** An Open Australian Legal Corpus layer that backs the live
+   layer when a direct fetch is blocked.
 
 ## Quick start
 
@@ -116,7 +144,7 @@ and AGLC4 prompts once the `jurisd` MCP server is registered.
 | --------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | `search_cases`        | Natural-language case-law search across all AU/NZ jurisdictions; authority ranking; title/phrase/boolean methods; pagination. |
 | `search_legislation`  | Search AU/NZ legislation with the same method/jurisdiction/sort controls.                                                     |
-| `fetch_document_text` | Fetch full text from an AustLII URL (HTML, PDF).                                                                               |
+| `fetch_document_text` | Fetch full text from an AustLII URL (HTML, PDF).                                                                              |
 
 > **AustLII sits behind Cloudflare.** AustLII now serves a JavaScript
 > managed-challenge that automated clients — including TLS-impersonating ones —
@@ -124,11 +152,11 @@ and AGLC4 prompts once the `jurisd` MCP server is registered.
 > directly. Configure a **fallback source**; results are still AustLII primary
 > sources (`austlii.edu.au` URLs) recovered through another channel.
 >
-> | Fallback            | Env var               | Cost           | You gain                                                                                                        | You lose                                                                                                                                    |
-> | ------------------- | --------------------- | -------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-> | **Direct citation** | none                  | Free           | Queries containing a neutral citation such as `[2018] HCA 9` resolve directly to the canonical AustLII case URL. | Citation-only. It is not general natural-language search.                                                                                   |
-> | **Exa**             | `EXA_API_KEY`         | Paid/free tier | Search discovery returns canonical AustLII case/legislation URLs, even for obscure cases.                        | Discovery only (URL + citation); full text is fetched separately.                                                                           |
-> | **none**            | -                     | -              | -                                                                                                               | Search returns a degraded result whose warning names the env vars; document fetch still falls back to the local OALC corpus when available. |
+> | Fallback            | Env var       | Cost           | You gain                                                                                                         | You lose                                                                                                                                    |
+> | ------------------- | ------------- | -------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+> | **Direct citation** | none          | Free           | Queries containing a neutral citation such as `[2018] HCA 9` resolve directly to the canonical AustLII case URL. | Citation-only. It is not general natural-language search.                                                                                   |
+> | **Exa**             | `EXA_API_KEY` | Paid/free tier | Search discovery returns canonical AustLII case/legislation URLs, even for obscure cases.                        | Discovery only (URL + citation); full text is fetched separately.                                                                           |
+> | **none**            | -             | -              | -                                                                                                                | Search returns a degraded result whose warning names the env vars; document fetch still falls back to the local OALC corpus when available. |
 >
 > Resolution order: direct citation URL when present, then Exa, then a degraded
 > result. The document source remains AustLII throughout.
@@ -143,12 +171,12 @@ commands exit 4 for degraded source coverage.
 
 ### Citation + bibliography (AGLC4)
 
-| Tool                  | What it does                                                                                                         |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `format_citation`     | Format an AGLC4 citation. `mode`: `full` (default), `short`, `ibid`, `subsequent`, `pinpoint`.                       |
-| `resolve_citation`    | Resolve a citation to its source. `mode`: `auto` (default), `validate` (AustLII existence check), `search`.          |
-| `cite`                | Write to the local citation cache. `action`: `add` (default) or `refresh_source` (conditional-HEAD freshness check). |
-| `bibliography`        | Read the local citation cache (no network). `op`: `get`, `list` (default), `export` (`.bib`), `cited_by`.            |
+| Tool               | What it does                                                                                                         |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `format_citation`  | Format an AGLC4 citation. `mode`: `full` (default), `short`, `ibid`, `subsequent`, `pinpoint`.                       |
+| `resolve_citation` | Resolve a citation to its source. `mode`: `auto` (default), `validate` (AustLII existence check), `search`.          |
+| `cite`             | Write to the local citation cache. `action`: `add` (default) or `refresh_source` (conditional-HEAD freshness check). |
+| `bibliography`     | Read the local citation cache (no network). `op`: `get`, `list` (default), `export` (`.bib`), `cited_by`.            |
 
 ### Local data modules (offline recall)
 
@@ -162,7 +190,7 @@ and snapshot date (plus a staleness advisory when the snapshot is old).
 | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `get_provision`         | Deterministic provision lookup (e.g. `s 18` of an Act). No embedding, no ranking; typed not-found so the router can fall through.                      |
 | `get_act_structure`     | Containment tree of an Act (Act → Part → Division → section/schedule/clause) over `act_provision` edges, closed-world.                                 |
-| `find_citing`           | Documents in installed modules that cite a target, with each citation's provenance span.                                                              |
+| `find_citing`           | Documents in installed modules that cite a target, with each citation's provenance span.                                                               |
 | `semantic_search_local` | Vector recall: the query is embedded locally (bge-small, offline, no key) and ranked by cosine over chunk embeddings, with optional facet pre-filters. |
 | `list_data_modules`     | Introspect installed modules: coverage, doc/chunk counts, embedding descriptor, load status, snapshot date and staleness.                              |
 
@@ -279,6 +307,30 @@ an endnotes-boundary flood; citation precision is internal-ref over-firing on
 structural lines). The published module exposes the resulting data artefacts;
 evaluation reports remain part of the module publishing workflow until a public
 report location is available.
+
+## Where this is heading
+
+The sections above describe what ships today. The longer arc for jurisd is a
+secure, local-first workbench for high-trust legal work, built so serious
+reasoning can happen on your own machine with every act provable and nothing
+leaving without your say-so. Planned directions (design intent, not yet built):
+
+- **A sandboxed local agent runtime.** Run a research and drafting agent over your
+  own sources inside an isolated, encrypted workspace, so sensitive and privileged
+  material cannot leak.
+- **Tamper-evident provenance.** An auditable record of every step, and an
+  Evidence Pack you can hand a reviewer to verify process and sources (not legal
+  correctness).
+- **A first-class desktop app and TUI.** Matter view, source and provenance pane,
+  review queue, and a drafting canvas, for both terminal-native researchers and
+  practitioners who just want a clean interface.
+- **An SDK and plugin base,** with connectors for the tools you already use (Word,
+  Obsidian, Zotero).
+- **Source-anchored drafting.** Work-product where every assertion carries its
+  citation, gated by human review.
+
+Nothing in this list is claimed as built. See [ROADMAP.md](docs/ROADMAP.md) for
+the sequenced workstreams and review gates.
 
 ## Licensing
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,14 +14,31 @@ surface details live in the focused reference docs:
 
 jurisd is a pre-1.0 Australian and New Zealand legal research tool with:
 
-- MCP tools for live AustLII search, source fetching, citation formatting, and bibliography work.
+- Tools for live AustLII search, source fetching, citation formatting, and bibliography work, callable from the CLI or the AI assistant the user already runs.
+- AustLII discovery recovered through Exa-backed search and direct citation URLs when AustLII's own search is Cloudflare-blocked.
 - Local data-module plumbing for deterministic provision lookup, local semantic recall, and citation graph traversal.
-- CLI parity for the current MCP tool surface.
+- CLI parity for the current tool surface, plus a TUI search shell.
 - Day-0 packaging, Docker, and install documentation.
 
 The main product gap is not another historical implementation phase. It is
 turning the existing engine into a governed workbench with reviewable source
 custody, offline data modules, and operator-safe workflows.
+
+## North star
+
+Beyond the near-term workstreams, jurisd is heading toward a secure, local-first,
+sandboxed workbench for high-trust legal work: serious reasoning done on the
+user's own machine, every act provable, nothing leaving without explicit, recorded
+authorisation. The themes below are design intent, sequenced rather than
+simultaneous, and none is claimed as shipping:
+
+- A sandboxed local agent runtime with an encrypted workspace.
+- Tamper-evident provenance and Evidence Pack export.
+- A first-class desktop app alongside the CLI and TUI.
+- An SDK and plugin base, with connectors (Word, Obsidian, Zotero).
+- Source-anchored drafting, gated by human review.
+
+Each gets its own design before build.
 
 ## Workstreams
 

--- a/docs/diagrams/provenance-loop.d2
+++ b/docs/diagrams/provenance-loop.d2
@@ -1,0 +1,35 @@
+# jurisd provenance loop
+# Source for docs/diagrams/provenance-loop.svg
+# Render: d2 docs/diagrams/provenance-loop.d2 docs/diagrams/provenance-loop.svg
+direction: right
+
+machine: Your machine (local-first) {
+  style.stroke-dash: 3
+  style.border-radius: 12
+
+  you: |md
+    **You / your AI assistant**
+    practitioner · researcher · agent
+  |
+
+  jurisd: jurisd (local-first legal workbench) {
+    style.border-radius: 10
+    modules: Local data modules\n(provision lookup · citation graph · semantic search)
+    live: Live research\n(AustLII + Exa-backed discovery)
+    cite: AGLC4 citations
+  }
+
+  you -> jurisd: question
+}
+
+law: |md
+  **Australian & NZ primary law**
+  legislation · case law
+| {
+  style.border-radius: 10
+}
+
+machine.jurisd.live -> law: retrieves
+law -> machine.you: answer + verifiable citation\nto the primary source {
+  style.stroke-width: 3
+}

--- a/docs/diagrams/provenance-loop.svg
+++ b/docs/diagrams/provenance-loop.svg
@@ -1,0 +1,862 @@
+<?xml version="1.0" encoding="utf-8"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" data-d2-version="v0.6.9" preserveAspectRatio="xMinYMin meet" viewBox="0 0 2228 759"><svg class="d2-1405021153 d2-svg" width="2228" height="759" viewBox="-22 -65 2228 759"><rect x="-22.000000" y="-65.000000" width="2228.000000" height="759.000000" rx="0.000000" fill="#FFFFFF" class=" fill-N7" stroke-width="0" /><style type="text/css"><![CDATA[
+.d2-1405021153 .text {
+	font-family: "d2-1405021153-font-regular";
+}
+@font-face {
+	font-family: d2-1405021153-font-regular;
+	src: url("data:application/font-woff;base64,d09GRgABAAAAABD8AAoAAAAAGbAAAguFAAAAAAAAAAAAAAAAAAAAAAAAAABPUy8yAAAA9AAAAGAAAABgXd/Vo2NtYXAAAAFUAAAAswAAAQYE3QZVZ2x5ZgAAAggAAAoXAAANxE+Ol5loZWFkAAAMIAAAADYAAAA2G4Ue32hoZWEAAAxYAAAAJAAAACQKhAXzaG10eAAADHwAAAC3AAAAxFTfCNZsb2NhAAANNAAAAGQAAABkVz5aeG1heHAAAA2YAAAAIAAAACAASQD2bmFtZQAADbgAAAMjAAAIFAbDVU1wb3N0AAAQ3AAAAB0AAAAg/9EAMgADAgkBkAAFAAACigJYAAAASwKKAlgAAAFeADIBIwAAAgsFAwMEAwICBGAAAvcAAAADAAAAAAAAAABBREJPAEAAIP//Au7/BgAAA9gBESAAAZ8AAAAAAeYClAAAACAAA3ichM47LgVhHMbhZ5zP/bjf74NjjEE0NiAiIhE9nR1obUmlkxC3pViCEom/zNSS89ZP8nuRacnQlnyjI5ckucKOXfsOHDpy7MSpM+cuXLn1EEGjStW/6tJ1reIjfutOfMVPfMZ7vMVrvMRzPMVj3Mdd3DT97st0lM2nPYXKlh4tSa8+/QYMGjKsbcSoMeMmTJoybcasOfMWLFqybMWqNbl1GzZt8wcAAP//AQAA///z0i0aAHicfJZ/bBvlGcef9/XFF8d2nKt9Pjvxr7uLffHvxOfz5YdjN47jpE2cpE7TNGmb0jY0gUJHs6lVNwZjdLTatC0b/IE2NtDoJqENUUAqVGj/0JWF8UtIG9BBKqZJphqMjSxMQ5DzdGcnJH9sf/l0vvd9nvfzfJ/v80IdTANgCT8EOjCABXYADSBSLOVnBYEnZVGWeUYnC4gip9F7yhJCu5JEKkV05D7Mnb33XrT/HvzQ+h3d5+bnr82eOaN8v3xTSaDXbwIGHQB24yUwAAVgJUUhEBB4vV5nFa28wJOveK95d/iaCIvvzzdmb0xn/pFFX5mbk+/s6rpTmcFL63ctLwMAIEhW1nALfgTcAHVcICAlUykxYWfIQIDn9HraZreLiZTM6PWoVLpveOTcRPqgK9qcC2UOiYkDmfhub0w4atrz8InbHy51+FIuru90qXQ218Ylowlt/xkAdAMvgVE7N83SIs3TLD2Dvq5c/+wz1IGXCq8Pfjy4mUsAPwK+/5WLmorESyKl16OD+x4YGb0wlT/kijlzidxR6dRt/E7r99723lZLR/Skmlv7Tpfu/hG949cDykdsuJYPPImXVH4iJVIzEyqMWp6v4iWoq75n6ZkJ5MVL688NwsY5cBQvgVX738qIgYBEiRSvE3i7naZm9v19kNCRY/s+HiQIEi8pcxcSJ5JoYv0u9LPzHQtJ5QlAlQoAWsFLYAEQJZ3I2O2MmErJsqijf3dterLJ20RQnGXv1DUF/fhKa8HvL7ReUU4qWvwoAPpEqzeIEmIllkYsHUXTykvoF8qv0KEEdhQ61m8OAmCVI3oarUIztAIwnApSTmoQSUFDSlO8KhZBxamBfbF3zw9/SoXbQrvdPu5Y9/R4ntRxe+x8hj97JGHa1Tc+SXk7eZ+tyx6884DyVrcrlOO85y3peNAPGEqVNfQ5XgZrrXICT/KUSJPVWDYtkJTU4tN2Owpyu3w6MlfC7Fjb4aM9hwvpsZ4B707elzWx7gRefnG/W3jg1MTpzMD8zPgxzldxMdUaxCpr6Cm0Cq7/pw9Vqjt2LqT7TmTaB5whOu6ODAgT/Vy3vZUdN6UXx0uLaY5JWR3xyc6JebdNdrMqs3hlDV3fOEOVmba5IIkbsGRpM9B/DpzsOSKHMj5iIk/qXCPOnWlvl0fIBgqm75wd+2rG0zzxwnpnlys40K+4mPhE59QxwFr+f0Cr4ADvthPQNj3JbjaajtVQIabv9kx2Tj50K8LK83VTBb6nxe0dewUR2S5xj6l3cWx8MXP3gtlpKB6kqZTNgwK7i2MaJw8AyuI/Vr2Gl2QpWePEc7Taf9QtudzALibUtKPFlZ+fR49n6oq7pwxk1jRb7FcOAYAOohUf+gitQgf0QnFTRVJgy4+2qUir+rfp9TwnVGtQq7luo+a0zW6tPvNcoPrNv6fvCrA7nJzVIST2dthazU/MUUz7eELgzDv8HbOTk+mTI6HedDic7k0V9orxvY1sU7Nj+P181ttlJ4xtLm/MTNjyYWk0RNZlmyRvciRIGVtsjEfujY7E0dNZSUqnJSmrXOgNcM0EYQ3RQkxjUwJAb+NlsGl9vKFRiqeq+qRKJR1fTBQHS5F2f48fL784x8aPHFJeRcF8JuBXHoNKBQYA4Fl8GQfUrgQ9xO4GgEql8k5FgGe09/Hq+2/AZswyXgZT1VtEq0haeYGkS3t0bxx4/MrMDw7gZcWD4Kqy8rfbv1VbU1mDd/Cy6hUqe0qkNuX9RCxYajQQJGmst5u6JHx8/SErhVCGIKqx8CdoFVgtluovapW2nZLc/C3lSZ1vJNyZtQRGI8O7SpFYKl+KxFN5VC7w8Y5IMLlx9GHlsdrPBkO0WmNYi7GVYZ7U8aObELXNtjGs9cI/0SpYoGVbL2z3C9pmR5ae+Wx2vid9PJs9ns4Wi9nM6Gitj9OLpfHFdH5+Yu/Cwt6JedC8SESfo9VaH3+ZnabQgMDQ1q1epGbKjoVnj/Yc7uT6OXxGs6JsK5t5DT/b6Wo7f6p0OuNpnryI9Nu8SPULEV3fiFMnydr2m00hi5Ruq1+gBwj3cKhqGjtZXJ97Y9MwXntyv6tNMw23O7ZeRPovHWNDO7NoVZ3ym6xrjlcF7RwKupkmk83i7Xei8v5YqmGIIBIZpTbfXZU1dD9ahZCmI0HWbEZKBgJCDG/6Qg21nfFgFdSbyVk+6MuH29tZsYXLhabHoqOuNmfKFwt72lv4fDQ4ZhJcspONep0c02BmpWDPmI9JWh0hF+OmjWZWjgm5Ni2+o7KGBvBJYGo65iVZFjUT2tTzh6O9QyMNA/ffz4bMHlOTLW6aGULmTN2FC/3KarTDQGRIo7bXcGUNvY7Kqu629QRVs+j3i0MT4fZAD6dy4UZMRw6hpPJ2PiOE0bTSPNLWDkjtQfR7VAYzgKgTrbURbBV1Lzw1edDIGAkj03Bwz29QWfmodYjnh1qRTWlWzwGAL6Oy1ldb123ZgddV72Ck7tHze4fqG0mivskwPD5ioOqJegs5OPrtuYLBYiDqmxryqKx8wPVzXD+HnFuemlEdn/f7B3jlC0DQCIAuoTI4AURZ2HJfIBm+dt8jycZHH5zuMzrMhNFu7Nn34M+nB83NjYTZYcopN09YQzZbyHrik09P2SM0HWZOaRxNlbjGoGWrJmR5G45GPNPkNjXV2wzBlMV4dfKY0WkkjLaGqfHnqPjAm3qiD9f1RFvRB8q/vEMcO+RD5vXV9pGoOjt8lTVcwo+AESToA7DaVAOqNp211uny1uGnJ+3qF7JYfSID6pgQqrXVnn9LNUb73aw/Eu45kPB3czYmMBDtzUf6/b79MU/cUrR2CVymxc4V2/yzzwynuKyrfZrn2jFu6fZ4+sLucGr95XhJiuRTTLDYGikEh7rD+c6WxGEheKRz55kk46vPN/hdXPAFOedyhuYkVy9gtefQn/A9YFAVJ4vq5FORWyVWQurw4OmFZQIRpuZGUfkLog5OTa1eaR5yMhFGSV5KoYeVr+UuqbyD8C6yoGb1zilLIh0sv5vNqnOkD+ngeXQfJqEdAFlqvj+ODPg9VZ9MddgymoMwb2UKhYzY3dXVfenWlXPnbsw5Dq8sLq4cBgSByjis1NYIGmm1prRNP619L2YKhUu1rx1zN86dWwEEDZVb0B78kpoTg0TUgIxp5dPHdMe/+EnVN7rRRbSAl1UNWgVZkBlZZGSGZEjhu21dRyzHDR2GecuRTmEQXXTPtsWcd5xwxNpm3fvUtRwsoDdwRL3za9d1SWt4+p3Ll/suX164mrl6NXO15m1wEZU37uKlEiqrvVZ5Ge8GGV9W11OaqVZl4vB6HQ6vF+92Ox0ej8PpBkDazP0lKtfm5Ia/qdag99n9ZsrgMLc6Sunr9XUZXZ0Ywe71v+7eDwj6KmvwPCyqMZgtMb7p5Hmng+dNfIub590tPPwXAAD//wEAAP//S7zt7wAAAQAAAAILhY75bpdfDzz1AAMD6AAAAADYXaChAAAAAN1mLzb+Ov7bCG8DyAAAAAMAAgAAAAAAAAABAAAD2P7vAAAImP46/joIbwABAAAAAAAAAAAAAAAAAAAAMXicHM2hSsVgGMbx//MuCCKKbaCMDxVhyLYyEBSDwWR7m58gGL0Skzeh92GexWIxnHzqOSs7O+k7bO0Jv4e/ffBEBxbI7JbWjoj2Rqs9opZEeydqkZKdUGmktRJXR21XNFpT64JCI5UFnIEHNulfK5yEZ3e4neNWzN7nzzOuL07l5BZ41B8H9kuubw7n/UpQz7GuKdlyrwZXw6Ve2NcnN+o5Y8Ah/UytyewAAAD//wEAAP//d4wq6QAAAAAsACwAUACAAJYAyADUAOQBBgEkAToBcgGmAdQCBgI6AlwCyALqAvYDAgMcAzgDagOMA7gD7AQgBEAEgASmBMgE5AUeBUoFegXeBgIGDgYYBjIGTAZcBnoGjgaaBrAGzAbiAAEAAAAxAIwADABmAAcAAQAAAAAAAAAAAAAAAAAEAAN4nJyU3U4bVxSFPwfbbVQ1FxWKyA06l22VjN0IogSuTAmKVYRTj9Mfqao0eMY/Yjwz8gxQqj5Ar/sWfYtc9Tn6EFWvq7O8DTaqFIEQsM6cvfdZZ6+1D7DJv2xQqz8E/mr+YLjGdnPP8AMeNZ8a3uC48bfh+kpMg7jxm+EmXzb6hj/iff0Pwx+zU//Z8EO26keGP+F5fdPwpxuOfww/Yof3C1yDl/xuuMYWheEHbPKT4Q0eYzVrdR7TNtzgM7YNN9kGBkypSJmSMcYxYsqYc+YklIQkzJkyIiHG0aVDSqWvGZGQY/y/XyNCKuZEqjihwpESkhJRMrGKvyor561OHGk1t70OFRMiTpVxRkSGI2dMTkbCmepUVBTs0aJFyVB8CypKAkqmpATkzBnToscRxwyYMKXEcaRKnllIzoiKSyKd7yzCd2ZIQkZprM7JiMXTiV+i7C7HOHoUil2tfLxW4SmO75TtueWK/YpAv26F2fq5SzYRF+pnqq6k2rmUghPt+nM7fCtcsYe7V3/WmXy4R7H+V6p8yrn0j6VUJiYZzm3RIZSDQvcEx4HWXUJ15Hu6DHhDj3cMtO7Qp0+HEwZ0ea3cHn0cX9PjhENldIUXe0dyzAk/4viGrmJ87cT6s1As4RcKc3cpjnPdY0ahnnvmge6a6IZ3V9jPUL7mjlI5Q82Rj3TSL9OcRYzNFYUYztTLpTdK619sjpjpLl7bm30/DRc2e8spviLXDHu3Ljh55RaMPqRqcMszl/oJiIjJOVXEkJwZLSquxPstEeekOA7VvTeakorOdY4/50ouSZiJQZdMdeYU+huZb0LjPlzzvbO3JFa+Z3p2fav7nOLUqxuN3ql7y73QupysKNAyVfMVNw3FNTPvJ5qpVf6hcku9bjnP6JNI9VQ3uP0OPCegzQ677DPROUPtXNgb0dY70eYV++rBGYmiRnJ1YhV2CXjBLru84sVazQ6HHNBj/w4cF1k9Dnh9a2ddp2UVZ3X+FJu2+DqeXa9e3luvz+/gyy80UTcvY1/a+G5fWLUb/58QMfNc3NbqndwTgv8AAAD//wEAAP//B1tMMAB4nGJgZgCD/+cYjBiwAAAAAAD//wEAAP//LwECAwAAAA==");
+}
+@font-face {
+	font-family: d2-1405021153-font-semibold;
+	src: url("data:application/font-woff;base64,d09GRgABAAAAABEQAAoAAAAAGdQAAguFAAAAAAAAAAAAAAAAAAAAAAAAAABPUy8yAAAA9AAAAGAAAABgXqrWeWNtYXAAAAFUAAAAswAAAQYE3QZVZ2x5ZgAAAggAAAn6AAANjPsVhnloZWFkAAAMBAAAADYAAAA2FnoA72hoZWEAAAw8AAAAJAAAACQKgQXxaG10eAAADGAAAAC6AAAAxFffB+9sb2NhAAANHAAAAGQAAABkVbRY5G1heHAAAA2AAAAAIAAAACAASQD2bmFtZQAADaAAAANOAAAIcCYSZQ5wb3N0AAAQ8AAAAB0AAAAg/9EAMgADAhoCWAAFAAACigJYAAAASwKKAlgAAAFeADIBJgAAAgsGAwMEAwICBGAAAvcAAAADAAAAAAAAAABBREJPAAAAIP//Au7/BgAAA9gBESAAAZ8AAAAAAesClAAAACAAA3ichM47LgVhHMbhZ5zP/bjf74NjjEE0NiAiIhE9nR1obUmlkxC3pViCEom/zNSS89ZP8nuRacnQlnyjI5ckucKOXfsOHDpy7MSpM+cuXLn1EEGjStW/6tJ1reIjfutOfMVPfMZ7vMVrvMRzPMVj3Mdd3DT97st0lM2nPYXKlh4tSa8+/QYMGjKsbcSoMeMmTJoybcasOfMWLFqybMWqNbl1GzZt8wcAAP//AQAA///z0i0aAHicfFZ9bFvV2X/O9Y1vHDtO3OvrW39/XPveJE5sx9fXN2lix2lSN3E+66RJm34kTUsKhaYfLvQFtcD7vlVVCgtlQkPrkMYkpA5N00YrdUJbNwhs6yYEomuZKKPbGB0CT5NQM8Km5t7pXDtpgqb9kZybk3PO85zf8/v9ngMVMApA9BPPgw4MUAPrgAEQLX5LSBQEjpJFWeZYnSwgCzWKvlLOX2uJkNEoGYm90fzYoUNoZJZ4fumhvvv37bu1e/t25VvvvqdMoZfeAyBUBYCIEXNgAAsATYkCzwucXq+jRZoTOOoD9gJb6zaT1e7ijTM3HhP/IKKdw8OJ2aR8UDlMzC0dffVVAAAEzeoCwRPnwQVQEeB5KZFMinEbS/E8F9DrGatNjCdlVq9H2/Knh7acyaenvGl7ipdGotP5xm5Xum6/afCFhx789pa4v8/hbT2QO/xEyNMbacZnjwCgT4k5MGp3ZvyMyHCMnxlBZ5XPi0XkI+amL0y/Mb2SR5I4D97/lEc5DYmTRItej+7b9sxw/pnx7B6cSmT8wZlpV7z2xCf+g+VURF/fev8Ts4efqDF/Y1L5k7+plAv8mpgDHc5FtIwcwyCUc/w9MQcVpXk/M3IM1RJzS9enS/iMABApYg5o7f80K/K8ZBEtnE7gbDbGMnL87S6SNB4qDcSccu7p+CMyci0dRYefThyVlY8BqXcB0D+JOagBECWdyNpsrJhMyrKoY15/68Rms6uWrPWYNz/6yzvoOxdCm3h+U+iCct8dLX4dAPpSqzOIEvJLfgb5mTrUrvwZ/Uh5E3Vk0V+ns4pjGoCAqLqA3kSLYAcOgA1gEGUNP0rQ0GQsHOaIgKHUavt6ZsvZF5AQD27yN9Tv37Bzx2Ql6e+jPM2ufYN1puHM0Hit0OqyDjj4g/uVj5IufsJtn60WQ34P4Hi96gJhIOZhHXhw1QSO4iwiQ5ViWbVAUoLnAhRjsyE5m9FV7SjovLnQzpn2yaHmjfGWRItDNGUSxPzlvDNw5sjo8Y7JsZFcXr5to/Hd69UFdBktgvO/cAJT09b1YEf3kc5o1tlC17Ftfb0b3CITDYyaUoUt+ULKx/ZZ6Ilc74Td0u/xAAFhdQEViXmgMdtKOGkHC5K4jJAsLQf5x87Ztimpoc1FFiYrSWePSY7Z4/Zo1wbTmUeHj6Xd9qGLS2nJyU/Kt9l1WweGRkHDBuf+PlqE9V9jtI2xUn7bcuo6EeOjR87u2Uzn/a1dE5EK5WrlYJtPdgrc2MWb8Xi4C99i+Fi67YFNQWtnD23pYT0o1trZUeKnEwBNEO+UfIWTZClRxogLMFhvll0bN/aPO2K1NqczPTWFzo1ViAN7q6gx04i0QzkMADqoUwX0L7QIcUhDv4YILyUwAphA0j3gRQZz3qrXcwFeKJlDudK6cqXxHF365gIC/mthwy4pS9v9jF1IbhetoZofT5hq46OJ2oDFWM01jW/fkXkkx8Wbg8F4PNaWa2roqnPy3R+4WsOpRtJU53FHa0i6O9w6WE9VbDWHHck+Xk9VWS3M+tZMbCiCriSiETEejSaUuZjXbaXcQX8I49ILgP5GzINV0+0yKS2cRUuTsvQWSG9/fKinEKz3NXuJ+cuT7qaZXcrbKJSKez3KK6CqkAaAq8RbBA9NAEBBBP4fQFXVa2ocfqPNR8vzp6AckyCIeTCVvESURYrmBIrpPaK7/Pj3Xzv5+AAxr2z++Kry0Y1tJ/F6dQG+JOaxL2AWWkTLCqdfS4mFWgNJUTVVXlMuQ3QvXWYsCI2R+lIcXSVaBL8WB3sJrs6aG1IrY+9kJentjSQ7LdxAZDB3LMRHWgshIdKKil3+SLSejy9fO6W8Uh6W8UOLZfzKMVbjh61icAVAVNzoi6zBr6yBu2gRar6m4DXmgEmC1qUObNx4IJXGv9PJdDqZTKXK6k0V8lsKqd0TvbkJrOGS76QJA1os6/dedmVmsgy9yni0+w/U7byvfVL2ZTy6vSXjccbniR8mHPyZo6PH0257/jxi7lmP5hFpVFyOUSHJ2tErQpBFi26VR6D/IZ1ZXjOK+oxXV7Xj5rJJzH8v7+BKRuGJLo0g5p5LlDA+jhZxB1/BuOxuJYAdOYFjrNW2WneGRcXxmFi1jySbWpTrJe2vVxfQc2gR9wg2wAuyZitSgueFCLHiA+UUWQ/BWPXX4vuCSf/GUB3vjTl8HXVT+UTeIzkkdyjYXhfIhKdNgjtn9wTsjJOpMnFyfWc+yGZp1su6PWYT1xLp2A4IrOoCmiCOgK3EW4mTZFnUmru1TN8vt27O9punTp7cVO2qslpF096hz8cqTp/e8fkYRW6ljKX8u9UF9BdUxBxbw39L2YY/xOyq8zW7CrsNOl+/aWYXSigfpuK+IBpWmB4+AghrTTujGkBc01p/8oOHB6uYKtLIVA0euoCKajDH87mgqjAl7ACI66ioaWj1vlUncOU3FUWd/79jbZVGiqRqDJkHOg21lSRlotoeOvlUa6W5kqTMlS2oqHLZYHBzQNXGLKcqzG1ukyBkuU+0eGYA9DtUBDuASAurwlDsvTjmF795QjayRtJgNUSPP/fiiXaTvZqsshkTCIq7rGGrNWzd9dWdPbZGhgmze/C5JjWp3d+xmgOyvAYKvf6A1WNmKNogRE2GNx7eamSMpIE25A5d9G77rZ6cICqiIS+6/YVvMxfY7P9iSR3Zg/uCS10gZonzYAQJOgFoKzaZkmjpsprlFVFj9VE2vEIWS18Uj7uEUKqp9v2u2VTfst7tFTydu+Ncq99qq8/FuwbqO4OegQZnuPrAuhbe1+5wh7bUC9PfzTQ7JXt42Ofi0Fe2mMOR5B3ByNL7zSOJpu6Eje8JNOUaB9LhLtleN+gLjoupgki7KnYbOIeP/0WkhVkXGm20xYGAddo79AQYMNNkEXc1DDct+SUaNweOOXWBRKTJYRaVT+8+NTy8dM7V77LHHEr+5UF0Vvnf7S9rNWyAa2g94vEbUpZEpuHv10ZHcZ/ogDtwHT1LUBADAFVbO6AOIjtxC/OSLTVSVuuY7HvpbDbd05JMtlycuXXq1K0Z39TN2dmbU4AgrA7CYnmPoCGN68lY9QVtfU86m71YXu3T9mr1n0JdxK9wTiwt6kyfDX72km7m7nmcQww9iU4TVzH3aEEWZFYWWZmlWEp4VtwwQx80dhhn6f0bxD70ZGi6qd1+5Ii9vWk6NI73BmAv+iPRjN/u2rtbKgn8xqVL45cu7b0yeuXK6JWyh8HPUHH5Xd1bQEWFAaT+lOiETcRbeL9FM84SRbw87/XyPNEZ9LiDQbcnCIC0fvpzVITaNT6G7UCvDzgFs62KMfrZY57udyorxnQVTWFCv3Q3kY/i+B3qAlyHczgOuyrOWW9jo9fX0GBqDAQa8Q/8GwAA//8BAAD//5fD8fQAAAABAAAAAguF/uexi18PPPUAAwPoAAAAANhdoKsAAAAA2F4RM/44/s8IbgPdAAAAAwACAAAAAAAAAAEAAAPY/u8AAAiY/jj+OAhuAAEAAAAAAAAAAAAAAAAAAAAxeJwczT0uBWEchfHnHHKJ3JCguLmmkkhmjIyZ0PqITPOPqF6FLeipbcES7ECnsQGVwg70EhUN8cpMd4rfyeMHLnkBN/nPp3Sek3xDpzlJ3yTfk/SVf11QepF9HxB6pfIhtX6odMSWlyndEJpwrKX85hVCa8TCOeGW8M7oY/zcEnpkpms2vUevT6b+YKZ3Vsd9R2GxrjN2tcGJei7UU+uKqZ5oLbY1ISA/D63B/AMAAP//AQAA//9BCSMMAAAAAAAsACwAUAB+AJQAxADQAOABAgEgATYBbgGeAcoB/AIwAlICvALeAuoC9gMOAyoDXAN+A6oD3AQOBC4EagSOBLAEzAUEBTAFXgXCBeYF8gX8BhYGMAY+BlwGcAZ8BpIGsAbGAAEAAAAxAI4ADABkAAcAAQAAAAAAAAAAAAAAAAAEAAN4nJyUQW8bRRzFf2unNhUiKghFqYSqOYLUrpMoqdrmgkMa1SKygzcFcdzEa3sVe9faXSeEj8FH4MYX4MypH4EDRz4ABw6c0byZxHVAkEaVmreemTfv//5v/sBasEqdYOU+8AY8Dtjgjcc1VvnL4zrdYMXjlbf23GMQ9D1u8Dj42eMmvwS/e/we27UfPb7Peu1Xj99nq/aHxx/UTd14vMp243OPH/CoUXn8IQ8aPzgcwLOG5wwC1hu/eVzj48afHtdZazY8XmGt+YnH9/ioueVxg0fNfX7CsMUGm2xgeHL99QxDmwE5JyQYIi4pqUiYUmLokHFKTsFM/8daG2D4lDEVFTNe0KLFhf6FxNdsoU5OafEZjzFckFIxxtAnoSSh4NyzHZCTUWHoEjO1Wsw6ETlzCk5JzEPCt7+lNSaTyiMKcv1idaeckDNhoHtGzJkQU7BFyAbb7LBLm3326LG7xHnF6Pie/IPPneuxx0u+lv6SVMrNEvuYnErVZ5xj2NRaKPefs8uUmDMS7RqS8J3qsQw7hDxlhx2e8/SdtC17k8qXGEOlrg2027pwhiFneOe+p6rW9tGee02mrrq1iMrvdLdnDGjpvFGtY3lmxDxXvwtS7Q7vpOaIWN017BNieOVZb5/MiktmJBwz9p4tkhjJp4oL+bZwdUIqlzNl2NY9V6WutitnIjocYuiJP1tiPlxisG/jZpo2lRZb00LZ8r2LHp8TkyrjJ0y0snhpse5t85VwxQvMDXdKTtWFGZX6UIorlM8jWvQ44PCGkv/3aKC/rr8nzK8T4qqzybDvu02k7kbmIYY9fXeI5Mg3dDjmFT1ec6zvNn36tOlyTIeXOtujj+ELenTZ14mOsFs7UMq7fIvhSzraY7kT74/rmH1/M6kvpd3lNWXKTJ5b5aGfLsmdOmwYetars6XOnJIy1E6j/mWaVjEjn4qZFE7l5VU2Fi/LJWKqWmxvF+sjck3WQq/Tshou/XywaXWa3BSobtHV8E6Z+e9pfXN+HemmoVQXPi1tqbO5jik5c7khV30ZCWeURHKulK/2zPdiyDWLCr2MkdRbt9pMlETri5sh1st/+3UkfYX643httqzTk2tHh+Keu+T8DQAA//8BAAD//9kvXF8AAHicYmBmAIP/5xiMGLAAAAAAAP//AQAA//8vAQIDAAAA");
+}
+.d2-1405021153 .text-bold {
+	font-family: "d2-1405021153-font-bold";
+}
+@font-face {
+	font-family: d2-1405021153-font-bold;
+	src: url("data:application/font-woff;base64,d09GRgABAAAAABD8AAoAAAAAGZgAAguFAAAAAAAAAAAAAAAAAAAAAAAAAABPUy8yAAAA9AAAAGAAAABgXxHXrmNtYXAAAAFUAAAAswAAAQYE3QZVZ2x5ZgAAAggAAAoTAAANlI6LfCRoZWFkAAAMHAAAADYAAAA2G38e1GhoZWEAAAxUAAAAJAAAACQKfwXwaG10eAAADHgAAAC3AAAAxFq7Bxlsb2NhAAANMAAAAGQAAABkVd5ZEm1heHAAAA2UAAAAIAAAACAASQD3bmFtZQAADbQAAAMoAAAIKgjwVkFwb3N0AAAQ3AAAAB0AAAAg/9EAMgADAioCvAAFAAACigJYAAAASwKKAlgAAAFeADIBKQAAAgsHAwMEAwICBGAAAvcAAAADAAAAAAAAAABBREJPACAAIP//Au7/BgAAA9gBESAAAZ8AAAAAAfAClAAAACAAA3ichM47LgVhHMbhZ5zP/bjf74NjjEE0NiAiIhE9nR1obUmlkxC3pViCEom/zNSS89ZP8nuRacnQlnyjI5ckucKOXfsOHDpy7MSpM+cuXLn1EEGjStW/6tJ1reIjfutOfMVPfMZ7vMVrvMRzPMVj3Mdd3DT97st0lM2nPYXKlh4tSa8+/QYMGjKsbcSoMeMmTJoybcasOfMWLFqybMWqNbl1GzZt8wcAAP//AQAA///z0i0aAHicbFZrcBvV/f3dq9WuLUu2pdVqJdmyHivtSn7Illar9TOKYyl+YCWOM3ZicOwkwz8x2HECMcSA/6UzpEwBp0CdBgMlMC2dPiZ0wqSdprRupw8eGdIvDTRf2gBtJmWYaRCMh2HAXnXuSrbjTD/Yd2e19/7OPb9zzr1ghAEAfBCfBgOUQgXYgAOQrX5rSJYkgVFlVRV4gyohKzOAbdqPXpUiVCRC1foWvQ+Pj6PsGD69OnVX9uDBL8bb2rSzv35DO4WOvwGA818B4C48D6VgBWAZWRJFSaBpAyuzgiQwNyqfqrBUWSiz66vLr1/+fvjtMOprb49Ny4kj2rfw/OrMiy8CACCI5pdxE16EKgBjQBSVRDIpxx08I4pCgKY5u0OOJ1WeRvsGn9w9dGowdbd/h0sV6nvrhnvCKeeOQXP/945MPb9LDozxnvjYtruPBV2j+wFBFgB9iuehTN8v5+dkTuD8XBYtal9fu4Yq8PzcY4+cmVvHkMaL4P1fGIoQFEGRrTSNjow8O7TnmT3dh3xZV3Nt//7Ru+yieepm4L4ikIR/zFFz7ODdx0ymY7Pae/5oAQt8iOfBQLDI1uwCIaCI8Z94HoyF934uu4Awnl/NzRW4yQLgfjwPrP47y8uiqCiyVTBIgsPBcdnnfraVosrnyWC04Hntt88kvtl6Y3UGZb6TnGv9N1kj/yUA5vA8VADIikHmHQ5eTiZVVTZwS2+ebS13W6jyakvbC29+jF49E8qIYiZ0Rhv9WK8fBEAreo9BVpBf8XPIzwWRT/savaF9iIQR9Ku5Ea13DgBDbX4ZvYdWwAUCAB8gJKo6f4yks8lZBaIPlVCp9/V36YGTC1iIeLcGlcbJ1vFDsybK213iCrE72r3mPakdeyv8kpM74AlO369dl6uF+3l2j6nO4+SB1OvML2MHXgJ7sWuSwAhWmWP0Yg7OTtNSPKkkhADDORwo4+/yUObjC5QnHWjf29g+vldMDtdH7GGz36fgpXP9bs+W+/qHHkrNbu9/vOFdW3lh//lltIRWwH27LjZkwdM0cmWOdvY8mI52V2cEn5JKNTmjbGto2NzxwODumY4aftzT37k1y1Xs91WBjl3KL6MVvAQs+Na40heWSHPXWVpT3+ejR9vGE5FmF70wa6Lc27FTsrF1diHZaH7qoV0PbKl29v90tSvmFmbtrndt5V3dvRnAOvaP0Ao4b1M1oYbxOxxynGA3yAlSBXm779/WNdXWva+RwtpV0/aYkoyJYy9ckOoDSfOWmcFdM6nUZJoNlSZl/4i7BrVGlMaCRp0AaAZfIqNsFRT1NvMQ21nv3LYtONDlTVRWWdzmqpqREfT/R4xVynDCTE8ZjX6x5rj2GIABAvkGzKAVaIQ26NOZEZUEIYKISVnbAi9zQqHDQkDS+0DkZadpA2l4kTS28CwERP2Tz1vHmrvZKp/THWkdU+r9v9zJlCb2qh6vLRAZGD2QnuvzSJLHI0mR+FYpJLv85qqOK+7m+vYwZQl7q+KVlC1d174zbJ4sC9hb+oKmCgdra+uSd0XRpdqIFAmHI7XaQtDFVxoMTle1p8BNJ2m2rlHi36I2Oatg1VEy1s4FpvqO+K7eBY+vOuzES+dGXHWT+7TLyJ8Mu3jtdcjnQQWAf+ArWIQGAGAgCk8C5PP5v+Tb4QP9fWPx/fx6zRq8BOZCpsiqzLCCxHCdT1MvvfLz37x8LIWXtOk3L2t//0P3w+T7/DKy4SWSD0SJVtm6Lux3+tsWrKVGhraZQ+a77sDC6lXehtARI1OoY/CgFfDrdUimkK5v2iGzPnYSb2+PKZ2svy82cMeCxxdqIv8aUW6rt6EuHIitbbtJe704rPGHVor8FWvcyt+sifJl1wlEuVRNwyb+Cj7QNVVx2wmzERFFxSBH6mg6fTSVmk6np1MN0WhDtKGh6OGOmd2DD3ScyG7t7CdWLuRPD3agFWChBoDfQKfLUpR4jt2IH4LT0yvdOdE+nvS1u407xeRwXa09fBH/JOYWnjg+NJuqcu18FgXXw4dkRA9a0df3ARgVVV92zVyyKlsNt2YEuod2bQsUgmILSbrr6yFx8bl+p1cPCo8vtroXBTdSoqgX9DRaAdumPhbcW2C4ql/kqk1Oi6uyusOOcnviMaPxUYqKxLUPAQGXX0YvoxWQdP1IKkkWQqooRbGS2FiMszv4GszZ6Suxw+K2QMrrr/FE3TVt4XuGWvZ4t7kT7pYW0dcRmTCL3lFXFc9aHazJHGyJZIYl5167Q3K6ysuElmjXvoK3rPllNI1ngNe7qiiCoqqyfshvBDOM7kz3Wx8+cULwmF0mnlXN9w5fOkKfPHn87doQTU3S5sJa7fll9CXKEZ1t8oC1GMd/29W7UOOrFh0Ls2UGb595ch9KaB8oEbcH9WiVmVA9IOI3lEc5sADIm47ZCz8+vdXEmqhS1tR56gco90koK0nZ0Cda5Vp+4hzK6T66dd4tKwjFuxXDnJ77bhNtoinGUqo+2lxawVBMKdP47RPnGhgLQzFlTD3K3Qj1iGKfcEMfe0I3tMq3hO3h8HbhLb1eOQBaRjlwAcisdEsZht+oU7749Nl6k8NEldhKAovPPH+2ycybqVJ7qYTwzQGujuPquIH8Z4NcPcfVOQbJuub8FrSKcsRlGzpQ1U1UlONZh7/CzdhKQmET8/vT3WU2E1ViLW0/dY5v3vlHmjqGjEGPG/3r/cD2kNAtvK+VbRmqJT0ygCu/jJ/Ai1AGCUgBsHYSNgXzsgVXq+veJiZkHOQDVS48MaIo0bRE2qrqjx+VmYQmB+8KWLsPxLqbWK5uINk3HN4SqO4KukTz4zZF9La4hPBQbeTQfLIuEgllPKwL3bSF7VzUz1dLq9floXh6yCtkvI3ZxoF0bZfC+zrcvh3Rtmm5kqNOlAScXuFPoajbmw5aRf3cZwHQl/gRKCVKY2WCmdDNKn6FJQeEwL3yuBFRZnd5XPvPx7/o7UUlh727atzJKm168f/QN7RTxxYJ13VwCflRjNwnVUXm6r64NDFBzooOuA6fopcwA00AkNP73ZPPojD+gOiSL9DE69cv/nIqk0mNqvG4euHwtZMnrx0WD1ydvPfqQUDQlM+iyuIcSWeZ9JOz0/OjzfF482gqk7kgHrx67+TVA6I+FxBY8vtREr9FMPGsbLBc2n/pFcOhlRcIBhHtQz/E7xDtsZIqqbwq8yrP8Ix0uqNtip+xZC3HnVNtHQNoX/1ErMf54AlXT2yifoTMDcAYuomT5B6v38GVgsn/ev781PnzYxcnLl6cuFjMMXgP5dbu2J0LKKdVAsq/hltgN75C5lv1AC3oIxSNhkLRKG6pFYRa8kfsS87U91EOKjdlGYkDmg56IxVuE2vy8Au+7J9L6CkDJUXQZxqbvFMl9Tvyy/ApvEbq8LfUOSPKsijKslmRwooSlhT4LwAAAP//AQAA//+DIOWkAAABAAAAAguFAV+nNV8PPPUAAQPoAAAAANhdoIQAAAAA3WYvNv43/sQIbQPxAAEAAwACAAAAAAAAAAEAAAPY/u8AAAiY/jf+NwhtAAEAAAAAAAAAAAAAAAAAAAAxeJwczTFKA0EcRvH3fYGgmGjEGGKhRRgUjC52Cu4U/0YsHBBEWC+jN7AXz2Bj6wW0sPIyYjOy6X+P53du+QTn+ucrGieKH2l0SvGQ4heKx/XX+yRvcexM6IfkzJGHJN0z94yFLwlNOdesfjsROiAGD4RbwsuVj77RM6EPdvXEti9ovcFosMbcZtPrjPzKnifs6IalTsjquFbHme4Y64tDT1hoSkB961+9+QcAAP//AQAA//8vlR4ZAAAAACwALABQAHwAkgDCAM4A3gEAAR4BNAFsAZ4BygH8AjACVgK+AuAC7AL4AxADLANeA4ADrAPcBBAEMARsBJIEtATQBQgFNAVkBcYF6gX2BgAGGgY0BkIGYAZ0BoAGlga0BsoAAQAAADEAkAAMAGMABwABAAAAAAAAAAAAAAAAAAQAA3icnJTPbhtVFMZ/TmzTCsECRVW6ie6CRZHo2FRJ1TYrh9SKRRQHjwtCQkgTz/iPMp4ZeSYO4QlY8xa8RVc8BM+BWKP5fOzYBdEmipJ8d+75851zvnOBHf5mm0r1IfBHPTFcYa9+bniLB/UTw9u061uGqzyp/Wm4RlibG67zea1n+CPeVn8z/ID96k+GH7JbbRv+mGfVHcOfbDv+Mvwp+7xd4Aq84FfDFXbJDG+xw4+Gt3mExaxUeUTTcI3P2DNcZw/oM6EgZkLCCMeQCSOumBGR4xMxY8KQiBBHhxYxhb4mBEKO0X9+DfApmBEo4pgCR4xPTEDO2CL+Iq+Uc2Uc6jSzuxYFYwIu5HFJQIIjZURKQsSl4hQUZLyiQYOcgfhmFOR45EyI8UiZMaJBlzan9BkzIcfRVqSSmU/KkIJrAuV3ZlF2ZkBEQm6srkgIxdOJXyTvDqc4umSyXY98uhHhSxzfybvklsr2Kzz9ujVmm3mXbALm6mesrsS6udYEx7ot87b4VrjgFe5e/dlk8v4ehfpfKPIFV5p/qEklYpLg3C4tfCnId49xHOncwVdHvqdDnxO6vKGvc4sePVqc0afDa/l26eH4mi5nHMujI7y4a0sxZ/yA4xs6siljR9afxcQifiYzdefiOFMdUzL1vGTuqdZIFd59wuUOpRvqyOUz0B6Vlk7zS7RnASNTRSaGU/VyqY3c+heaIqaqpZzt7X25DXPbveUW35Bqh0u1LjiVk1swet9UvXc0c60fj4CQlAtZDEiZ0qDgRrzPCbgixnGs7p1oSwpaK58yz41UEjEVgw6J4szI9Dcw3fjGfbChe2dvSSj/kunlqqr7ZHHq1e2M3qh7yzvfuhytTaBhU03X1DQQ18S0H2mn1vn78s31uqU85YiUmPBfL8AzPJrsc8AhY2UY6GZur0NTL0STlxyq+ksiWQ2l58giHODxnAMOeMnzd/q4ZOKMi1txWc/d4pgjuhx+UBUL+y5HvF59+/+sv4tpU7U4nq5OL+49xSd3UOsX2rPb97KniZWTmFu02604I2BacnG76zW5x3j/AAAA//8BAAD///S3T1F4nGJgZgCD/+cYjBiwAAAAAAD//wEAAP//LwECAwAAAA==");
+}
+.d2-1405021153 .text-italic {
+	font-family: "d2-1405021153-font-italic";
+}
+@font-face {
+	font-family: d2-1405021153-font-italic;
+	src: url("data:application/font-woff;base64,d09GRgABAAAAABE8AAoAAAAAGngAARhRAAAAAAAAAAAAAAAAAAAAAAAAAABPUy8yAAAA9AAAAGAAAABgW1SVeGNtYXAAAAFUAAAAswAAAQYE3QZVZ2x5ZgAAAggAAApNAAAObNsucCRoZWFkAAAMWAAAADYAAAA2G7Ur2mhoZWEAAAyQAAAAJAAAACQLeAjVaG10eAAADLQAAAC8AAAAxFIdBGJsb2NhAAANcAAAAGQAAABkW0hewm1heHAAAA3UAAAAIAAAACAASQD2bmFtZQAADfQAAAMmAAAIMgntVzNwb3N0AAARHAAAACAAAAAg/8YAMgADAeEBkAAFAAACigJY//EASwKKAlgARAFeADIBIwAAAgsFAwMEAwkCBCAAAHcAAAADAAAAAAAAAABBREJPAAEAIP//Au7/BgAAA9gBESAAAZMAAAAAAeYClAAAACAAA3ichM47LgVhHMbhZ5zP/bjf74NjjEE0NiAiIhE9nR1obUmlkxC3pViCEom/zNSS89ZP8nuRacnQlnyjI5ckucKOXfsOHDpy7MSpM+cuXLn1EEGjStW/6tJ1reIjfutOfMVPfMZ7vMVrvMRzPMVj3Mdd3DT97st0lM2nPYXKlh4tSa8+/QYMGjKsbcSoMeMmTJoybcasOfMWLFqybMWqNbl1GzZt8wcAAP//AQAA///z0i0aAHicfFd9bBtlmn+edyYzieM4scf2xG4cxx57JrEdO/bEnjipnTjfTew0aZqSa5u0paUtbTkiekC50uOjqALugHCqTjoEV0R1JxDSURWttF+wK9hdAmzR7qqsYFlYlo/AtssCUZZdEJlZzdhJnEq7/1ivZvy+z/P8nt/v9z4DFRAAIP9MzgIFVVALNnAAyJyPomRFEXhKliSBZRWJ49jAvbhw72N0386Pm5/8OuKlh+55ZvSPe58lZ1eO4d0zd92l7rr/hhuuu3pVDeGvrwIAEO11AHyTzEMVWAE4VpZEURIYBlHmBElgP+x82USbaNotqz/HAzvzE7ZPb8Q75ubaj3SkD6kTZH5l7tIlAIS0tkxayePgBajwi2KyPUvkhJNnRVHwW4jD7nTKiZTCMwz6Rw+n2naeyndM1Ke4lNi5pzfgH+lq7msSAjPmvhNjhbO3DymhliYpc+DE5q6ZZNOmhLcV9BgCAKkj81Bt1M/6WJkVWB8rnMYjNeqHoS8tn8soWsh87s3er3pLOXWRx8Fv5PR3UlIERaYYBiO3nWrbdc9E14RL4ZTm7PUDASHfHUhzwftr3kgHZs2Pnhg7e/vgWmKds6n6uu/0qB81Bldzg2UyD5Sem0wJp8dO6+CsvsP/JPNQUXynZzx2G9pryPzKxd5SXQfJPHDGe46XUylFP4PSO8HqZ/1XiGYspoHR04WzYZqpNQ2SeXX3A/GbZNy9MofnH5KPJNRzRqxJANJI5qFWP4uSeafTOE6Rkfp3+eh4a1VtFcVH6u+cVP/UjoDzLwQGxOBQ4IfqnKbv1zQA4jH4AIKCPsXHoo9FEz6jXrbgAyZ1J47WxkhTLrryfi8AAUlbxr/iEtj1Kvh1lGVFpgRFYBhJx3gN8ud78pGRWVnKWGkuu6+7khambeLWQMSRaAj0Jb1x866pwTt2y82+jOoeDsZ6orG3RX9oy0yiO2PwFbzaMn5BFsChq4L3i5LACpzMsnIqJSecDruFSIksSbaLgp9hWafzipSxUvbuhwuSkwS2txrhk4G+ZGNbi39CiNplc7MvQxZe3OsJ79yhh+4JbZmRs5lQ8BPRDwhBbRkv4hI0bKjO4BDDOOyrrH5r64FIYV8ystnZyometh2pdGdTyul3F8wHZ/qPT8X8rjbe0T/X1zvotibswWItkrZMpLJa1rH7x+B12qg6sTBfQm8seC16UtOeF1c6roWPGLX8CJfADcHyeE6HnWF9zJpCKTmVSrYbFX6048bW0d1tSq7RXKH+pKqpL+RJ842eif/WCGVrEZKz5iP7Bua2RaLjiQbZ0j0edFllhxeD1fU1DXHvFCCEAfAhchl4nY9CNzHaVMKP1QVMhae6q3N1tWMZd8i2ybTJ6muptF5v3j+FT6crJkYma6oV1pQIT2bVaR0z1AK4hEvghWix/0pJxgwjbGQfw1Ab0Hs2vkMINAw0Z0csLnF7LDMe3rI7LmatFNd9kDueFib8YWe8QcjJjbHfip4k78/3HBYjO6b6/uWfEjofqT0H0RcO/UL0twxOt3V1gaE3LwC+RRbAZWh3nYcsJXA6jHqZlPfhQlsd3bItkk1WZvObaXq4YTg6QBauZoRYrsMbUF/DiL2+ZjQUVZ/WNP1M+IZcJCLovsdAdBgANE27T5PgL8bzWPH5wHoOn5EFMBf9Rc+DEySW9T5c2Eu+nn7p1rGZOTdZUD2Ir6sff3bLSUCIaMvwDVkAm45isl33G53PJQrclGNOFk4hWimGRZPT3G11kaMrj7JVlA1JF02vxSVXcAlCxdqLpfMlAJgNCJSDsa+bpcVJsTNeEZsOZlI0nS1kaHrIMRwZ0LEZdA6HB3BxSyCuNEfkXIe10V6Oz/pqHX9cgvryHK6FX4/Ysi26AX0jwrXgr+kS38ElqAVPuU6K5mJooyT+y1tnIyOzia17IqOzodYJOZXQf8yHdw0cn4oWf3t65/p7h/rm+nsHjfv2K03GL3CpqHm2LGMLEQw3Y7kN/mV6sJuhglNRQ/oJcTNHbN7/LfevS+T5Hm9rSfjew+cQSwYmfhr0rdYjGx5txKxQdGO5RisblYI+XyMJTkfLvfrBc+VGc+nc7WJszapXCogbjbrYlztxCerK+sKz4mo/qmlPvtXl2FTnDuS9GVyciWSq+iu7u9RLgNq32jKewiWQyhWebBclfa4oNxCH3ckb9sWcj8+42vgeMZRp6YimI1si0ZGGKCf7xHiqKdvets3c3ix6m6OCW/K6sy3hXDDQ2Gx3t3obRZt/c6S1P6jnvFlbxmlybM3rU4ruWLLhUmVe/72edhrTQ9X5QG7TSfOpNNXgt7irrXUxc3drrbsGbemKM2ey6hWbrbHRVKGwtfrZHdoyfo6Luk+snr2uOK5k98+uqWHYMxQZyOsXZPN2c69i9XKYUi9zLp2mOK26RwS5qMEuAPw9LkINgK780nXPyXjvUD5AMzRtDXCPFNQVXFQ/EUaFwJYAulR3ce8gAHkFF8F3zd71FSVQxXmQpW4U8nWISNduqrt71EoI0hZ33V3D7+6xGE89tbfhovqBv9/v7/djY9nKjSZhOBAYFtSvALXLAPirIg4CJ5XNJywvlGZPlo38ZtdYqNLC0rVNtVOTC/u3RiqtJrrOz80i+eiYU3LYWxzH/vzlLc6o0xnhj+tzy0taDD/ERXADsAZnjEthAyIWwpiaLC6bLZhz2SbzYkUlRVuDtv/Iqx+4uoZ/ybLpqkxCwE/Uz30FQcj70bryZawQ0bGioFZbJv3kcaiGOGQAODu/qlLKaGdKWeWmTkfWqfugIusrnhUlhpGK9BH19cfVYrdU7w53xkd2xfJhW9tYNJVKbY86csGWjHvQm29TYk2ZbGjvI+moMNAk9fLRHL4vRvhoh8D7RlfenhxMjWfdXamO6+KZqFzIetr3N4cPdPaebI9Ys/akXzof7WhwhQ8r3i26/nUCXiL/BiawA/gExaegTMmsEJSVVErnHYujw4L6hyqc3T4+aZ5UtZ+KjI2l7c32C+34mDqXzb7gyfka2uuhNM++hyZ06bOu3jjB/E7Ne8Z9qGmwFc3wY7yPsNAGHVhv/D+njeN15B09D74oYYVnjAGc/9d6n3J4pPXIsSq75ULP+W23vvqDGdcZ9Xf/Ez24V9T7elkbhyulvVLKps8luiHoIGPrkaNVttqEfsQF9xn0PRE7uEfkep7adutr39f3flfbi0+Rn+l5sijjMF7sUAtPUge/faxYxyn8P3yCvAoWAE5SJIVXeFbhWZ6VLjQNTNv2uyKVh9hDYnM7XvRMx5t9R+ijlrB3Hz8NCG1wCF8jIf1bREkKSTkpO2SH4Hjv/5/b/NyFQ6+kX345/UrJB+ESLq5+F3j3Fa7HRUOACENkFC6Si/oZnEGiIntOcI0Cb/cIZJR3unz1TlcToHH3v4GLOg7s+tRjeEicF6wuk72uwWe6uXCzpe9tU1WaYeNhElh5d3AHIPDaMtwPx/Q4fFmcQadLanDWB80NTnfE43RF4G8AAAD//wEAAP//z7oBhgAAAAABAAAAARhRcboVJ18PPPUAAQPoAAAAANhdoMwAAAAA3WYvN/69/t0IHQPJAAIAAwACAAAAAAAAAAEAAAPY/u8AAAhA/r39vAgdA+gAwv/RAAAAAAAAAAAAAAAxeJwczTEuBHEYxuHf+24pshLFoPmKvzHFKpQ2NAqrkSiIS2i1OifgHCqNckMjEaotFesAFFOgmPhk9gBPHl+yyTPoL1+8xVg/FB8zpqPojeILil45NZlep/EaoXtqVzT6oNYGI68iLxF8Enzltd4JftkeBOFlwgMaV/nde50TuslOh+x7hV1N2fMTE93lTNN89ISh5gw1otByosKB6pzpLB90y5Xm7CweOOovWqp/AAAA//8BAAD//1LuMKYAAAAuAC4AUgCEAJwA0gDgAPABFgE2AU4BhgG+AewCJAJeAoYCzgL4AwQDEAMqA0wDjgO4A+YEIARaBHgEtATiBQ4FLAVmBZIFwgYgBkgGVgZgBn4GnAasBsoG3gbsBwIHIAc2AAEAAAAxAIwADABmAAcAAQAAAAAAAAAAAAAAAAAEAAN4nJyU204bVxSGPwfbbXq6qFBEbtC+TKVkTKMQJeHKlKCMinDqcXqQqkqDPT6I8czIM5iSJ+h136Jvkas+Rp+i6nW1fy+DHUVBIAT8e/Y6/Gutf21gk//YoFa/C/zdnBuusd382fAdvmgeGd5gv/mZ4ToPG/8YbjBovDXc5EGja/gT3tX/NPwpT+q/Gb7LVv3Q8Oc8rm8a/nLD8a/hr3jCuwWuwTP+MFxji8LwHTb51fAG97CYtTr32DHc4Gu2DTfZBnpMqEiZkDHCMWTCiDNmJJREJMyYMCRhgCOkTUqlrxmxkGP0wa8xERUzYkUcU+FIiUiJKRlbxLfyynmtjEOdZnbXpmJMzIk8TonJcOSMyMlIOFWcioqCF7RoUdIX34KKkoCSCSkBOTNGtOhwyBE9xkwocRwqkmcWkTOk4pxY+Z1Z+M70ScgojdUZGQPxdOKXyDvkCEeHQrarkY/WIjzE8aO8Pbdctt8S6NetMFvPu2QTM1c/U3Ul1c25JjjWrc/b5gfhihe4W/Vnncn1PRrof6XIJ5xp/gNNKhOTDOe2aBNJQZG7j2Nf55BIHfmJkB6v6PCGns5tunRpc0yPkJfy7dDF8R0djjmQRyi8uDuUYo75Bcf3hLLxsRPrz2JiCb9TmLpLcZypjimFeu6ZB6o1UYU3n7DfoXxNHaV8+tojb+k0v0x7FjMyVRRiOFUvl9oorX8DU8RUtfjZXt37bZjb7i23+IJcO+zVuuDkJ7dgdN1Ug/c0c66fgJgBOSey6JMzpUXFhXi/JuaMFMeBuvdKW1LRvvTxeS6kkoSpGIRkijOj0N/YdBMZ9/6a7p29JQP5e6anl1XdJotTr65m9EbdW95F1uVkZQItm2q+oqa+uGam/UQ7tco/km+p1y3nEaHiLnb7Q6/ADs/ZZY+xsvR1M7+886+Et9hTB05JZDWUpn0NjwnYJeApu+zynKfv9XLJxhkft8ZnNX+bA/bpsHdtNQvbDvu8XIv28cx/ie2O6nE8ujw9u/U0H9xAtd9o367eza4m56cxt2hX23FMzNRzcVurNbn7BP8DAAD//wEAAP//cqFRQAAAAAMAAP/1AAD/zgAyAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
+}]]></style><style type="text/css"><![CDATA[.shape {
+  shape-rendering: geometricPrecision;
+  stroke-linejoin: round;
+}
+.connection {
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.blend {
+  mix-blend-mode: multiply;
+  opacity: 0.5;
+}
+
+		.d2-1405021153 .fill-N1{fill:#0A0F25;}
+		.d2-1405021153 .fill-N2{fill:#676C7E;}
+		.d2-1405021153 .fill-N3{fill:#9499AB;}
+		.d2-1405021153 .fill-N4{fill:#CFD2DD;}
+		.d2-1405021153 .fill-N5{fill:#DEE1EB;}
+		.d2-1405021153 .fill-N6{fill:#EEF1F8;}
+		.d2-1405021153 .fill-N7{fill:#FFFFFF;}
+		.d2-1405021153 .fill-B1{fill:#0D32B2;}
+		.d2-1405021153 .fill-B2{fill:#0D32B2;}
+		.d2-1405021153 .fill-B3{fill:#E3E9FD;}
+		.d2-1405021153 .fill-B4{fill:#E3E9FD;}
+		.d2-1405021153 .fill-B5{fill:#EDF0FD;}
+		.d2-1405021153 .fill-B6{fill:#F7F8FE;}
+		.d2-1405021153 .fill-AA2{fill:#4A6FF3;}
+		.d2-1405021153 .fill-AA4{fill:#EDF0FD;}
+		.d2-1405021153 .fill-AA5{fill:#F7F8FE;}
+		.d2-1405021153 .fill-AB4{fill:#EDF0FD;}
+		.d2-1405021153 .fill-AB5{fill:#F7F8FE;}
+		.d2-1405021153 .stroke-N1{stroke:#0A0F25;}
+		.d2-1405021153 .stroke-N2{stroke:#676C7E;}
+		.d2-1405021153 .stroke-N3{stroke:#9499AB;}
+		.d2-1405021153 .stroke-N4{stroke:#CFD2DD;}
+		.d2-1405021153 .stroke-N5{stroke:#DEE1EB;}
+		.d2-1405021153 .stroke-N6{stroke:#EEF1F8;}
+		.d2-1405021153 .stroke-N7{stroke:#FFFFFF;}
+		.d2-1405021153 .stroke-B1{stroke:#0D32B2;}
+		.d2-1405021153 .stroke-B2{stroke:#0D32B2;}
+		.d2-1405021153 .stroke-B3{stroke:#E3E9FD;}
+		.d2-1405021153 .stroke-B4{stroke:#E3E9FD;}
+		.d2-1405021153 .stroke-B5{stroke:#EDF0FD;}
+		.d2-1405021153 .stroke-B6{stroke:#F7F8FE;}
+		.d2-1405021153 .stroke-AA2{stroke:#4A6FF3;}
+		.d2-1405021153 .stroke-AA4{stroke:#EDF0FD;}
+		.d2-1405021153 .stroke-AA5{stroke:#F7F8FE;}
+		.d2-1405021153 .stroke-AB4{stroke:#EDF0FD;}
+		.d2-1405021153 .stroke-AB5{stroke:#F7F8FE;}
+		.d2-1405021153 .background-color-N1{background-color:#0A0F25;}
+		.d2-1405021153 .background-color-N2{background-color:#676C7E;}
+		.d2-1405021153 .background-color-N3{background-color:#9499AB;}
+		.d2-1405021153 .background-color-N4{background-color:#CFD2DD;}
+		.d2-1405021153 .background-color-N5{background-color:#DEE1EB;}
+		.d2-1405021153 .background-color-N6{background-color:#EEF1F8;}
+		.d2-1405021153 .background-color-N7{background-color:#FFFFFF;}
+		.d2-1405021153 .background-color-B1{background-color:#0D32B2;}
+		.d2-1405021153 .background-color-B2{background-color:#0D32B2;}
+		.d2-1405021153 .background-color-B3{background-color:#E3E9FD;}
+		.d2-1405021153 .background-color-B4{background-color:#E3E9FD;}
+		.d2-1405021153 .background-color-B5{background-color:#EDF0FD;}
+		.d2-1405021153 .background-color-B6{background-color:#F7F8FE;}
+		.d2-1405021153 .background-color-AA2{background-color:#4A6FF3;}
+		.d2-1405021153 .background-color-AA4{background-color:#EDF0FD;}
+		.d2-1405021153 .background-color-AA5{background-color:#F7F8FE;}
+		.d2-1405021153 .background-color-AB4{background-color:#EDF0FD;}
+		.d2-1405021153 .background-color-AB5{background-color:#F7F8FE;}
+		.d2-1405021153 .color-N1{color:#0A0F25;}
+		.d2-1405021153 .color-N2{color:#676C7E;}
+		.d2-1405021153 .color-N3{color:#9499AB;}
+		.d2-1405021153 .color-N4{color:#CFD2DD;}
+		.d2-1405021153 .color-N5{color:#DEE1EB;}
+		.d2-1405021153 .color-N6{color:#EEF1F8;}
+		.d2-1405021153 .color-N7{color:#FFFFFF;}
+		.d2-1405021153 .color-B1{color:#0D32B2;}
+		.d2-1405021153 .color-B2{color:#0D32B2;}
+		.d2-1405021153 .color-B3{color:#E3E9FD;}
+		.d2-1405021153 .color-B4{color:#E3E9FD;}
+		.d2-1405021153 .color-B5{color:#EDF0FD;}
+		.d2-1405021153 .color-B6{color:#F7F8FE;}
+		.d2-1405021153 .color-AA2{color:#4A6FF3;}
+		.d2-1405021153 .color-AA4{color:#EDF0FD;}
+		.d2-1405021153 .color-AA5{color:#F7F8FE;}
+		.d2-1405021153 .color-AB4{color:#EDF0FD;}
+		.d2-1405021153 .color-AB5{color:#F7F8FE;}.appendix text.text{fill:#0A0F25}.md{--color-fg-default:#0A0F25;--color-fg-muted:#676C7E;--color-fg-subtle:#9499AB;--color-canvas-default:#FFFFFF;--color-canvas-subtle:#EEF1F8;--color-border-default:#0D32B2;--color-border-muted:#0D32B2;--color-neutral-muted:#EEF1F8;--color-accent-fg:#0D32B2;--color-accent-emphasis:#0D32B2;--color-attention-subtle:#676C7E;--color-danger-fg:red;}.sketch-overlay-B1{fill:url(#streaks-darker-d2-1405021153);mix-blend-mode:lighten}.sketch-overlay-B2{fill:url(#streaks-darker-d2-1405021153);mix-blend-mode:lighten}.sketch-overlay-B3{fill:url(#streaks-bright-d2-1405021153);mix-blend-mode:darken}.sketch-overlay-B4{fill:url(#streaks-bright-d2-1405021153);mix-blend-mode:darken}.sketch-overlay-B5{fill:url(#streaks-bright-d2-1405021153);mix-blend-mode:darken}.sketch-overlay-B6{fill:url(#streaks-bright-d2-1405021153);mix-blend-mode:darken}.sketch-overlay-AA2{fill:url(#streaks-dark-d2-1405021153);mix-blend-mode:overlay}.sketch-overlay-AA4{fill:url(#streaks-bright-d2-1405021153);mix-blend-mode:darken}.sketch-overlay-AA5{fill:url(#streaks-bright-d2-1405021153);mix-blend-mode:darken}.sketch-overlay-AB4{fill:url(#streaks-bright-d2-1405021153);mix-blend-mode:darken}.sketch-overlay-AB5{fill:url(#streaks-bright-d2-1405021153);mix-blend-mode:darken}.sketch-overlay-N1{fill:url(#streaks-darker-d2-1405021153);mix-blend-mode:lighten}.sketch-overlay-N2{fill:url(#streaks-dark-d2-1405021153);mix-blend-mode:overlay}.sketch-overlay-N3{fill:url(#streaks-normal-d2-1405021153);mix-blend-mode:color-burn}.sketch-overlay-N4{fill:url(#streaks-normal-d2-1405021153);mix-blend-mode:color-burn}.sketch-overlay-N5{fill:url(#streaks-bright-d2-1405021153);mix-blend-mode:darken}.sketch-overlay-N6{fill:url(#streaks-bright-d2-1405021153);mix-blend-mode:darken}.sketch-overlay-N7{fill:url(#streaks-bright-d2-1405021153);mix-blend-mode:darken}.light-code{display: block}.dark-code{display: none}]]></style><style type="text/css">.d2-1405021153 .md em,
+.d2-1405021153 .md dfn {
+  font-family: "d2-1405021153-font-italic";
+}
+
+.d2-1405021153 .md b,
+.d2-1405021153 .md strong {
+  font-family: "d2-1405021153-font-bold";
+}
+
+.d2-1405021153 .md code,
+.d2-1405021153 .md kbd,
+.d2-1405021153 .md pre,
+.d2-1405021153 .md samp {
+  font-family: "d2-1405021153-font-mono";
+  font-size: 1em;
+}
+
+.d2-1405021153 .md {
+  tab-size: 4;
+}
+
+/* variables are provided in d2renderers/d2svg/d2svg.go */
+
+.d2-1405021153 .md {
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  color: var(--color-fg-default);
+  background-color: transparent; /* we don't want to define the background color */
+  font-family: "d2-1405021153-font-regular";
+  font-size: 16px;
+  line-height: 1.5;
+  word-wrap: break-word;
+}
+
+.d2-1405021153 .md details,
+.d2-1405021153 .md figcaption,
+.d2-1405021153 .md figure {
+  display: block;
+}
+
+.d2-1405021153 .md summary {
+  display: list-item;
+}
+
+.d2-1405021153 .md [hidden] {
+  display: none !important;
+}
+
+.d2-1405021153 .md a {
+  background-color: transparent;
+  color: var(--color-accent-fg);
+  text-decoration: none;
+}
+
+.d2-1405021153 .md a:active,
+.d2-1405021153 .md a:hover {
+  outline-width: 0;
+}
+
+.d2-1405021153 .md abbr[title] {
+  border-bottom: none;
+  text-decoration: underline dotted;
+}
+
+.d2-1405021153 .md dfn {
+  font-style: italic;
+}
+
+.d2-1405021153 .md h1 {
+  margin: 0.67em 0;
+  padding-bottom: 0.3em;
+  font-size: 2em;
+  border-bottom: 1px solid var(--color-border-muted);
+}
+
+.d2-1405021153 .md mark {
+  background-color: var(--color-attention-subtle);
+  color: var(--color-text-primary);
+}
+
+.d2-1405021153 .md small {
+  font-size: 90%;
+}
+
+.d2-1405021153 .md sub,
+.d2-1405021153 .md sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+.d2-1405021153 .md sub {
+  bottom: -0.25em;
+}
+
+.d2-1405021153 .md sup {
+  top: -0.5em;
+}
+
+.d2-1405021153 .md img {
+  border-style: none;
+  max-width: 100%;
+  box-sizing: content-box;
+  background-color: var(--color-canvas-default);
+}
+
+.d2-1405021153 .md figure {
+  margin: 1em 40px;
+}
+
+.d2-1405021153 .md hr {
+  box-sizing: content-box;
+  overflow: hidden;
+  background: transparent;
+  border-bottom: 1px solid var(--color-border-muted);
+  height: 0.25em;
+  padding: 0;
+  margin: 24px 0;
+  background-color: var(--color-border-default);
+  border: 0;
+}
+
+.d2-1405021153 .md input {
+  font: inherit;
+  margin: 0;
+  overflow: visible;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.d2-1405021153 .md [type="button"],
+.d2-1405021153 .md [type="reset"],
+.d2-1405021153 .md [type="submit"] {
+  -webkit-appearance: button;
+}
+
+.d2-1405021153 .md [type="button"]::-moz-focus-inner,
+.d2-1405021153 .md [type="reset"]::-moz-focus-inner,
+.d2-1405021153 .md [type="submit"]::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+.d2-1405021153 .md [type="button"]:-moz-focusring,
+.d2-1405021153 .md [type="reset"]:-moz-focusring,
+.d2-1405021153 .md [type="submit"]:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+.d2-1405021153 .md [type="checkbox"],
+.d2-1405021153 .md [type="radio"] {
+  box-sizing: border-box;
+  padding: 0;
+}
+
+.d2-1405021153 .md [type="number"]::-webkit-inner-spin-button,
+.d2-1405021153 .md [type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+.d2-1405021153 .md [type="search"] {
+  -webkit-appearance: textfield;
+  outline-offset: -2px;
+}
+
+.d2-1405021153 .md [type="search"]::-webkit-search-cancel-button,
+.d2-1405021153 .md [type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.d2-1405021153 .md ::-webkit-input-placeholder {
+  color: inherit;
+  opacity: 0.54;
+}
+
+.d2-1405021153 .md ::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  font: inherit;
+}
+
+.d2-1405021153 .md a:hover {
+  text-decoration: underline;
+}
+
+.d2-1405021153 .md hr::before {
+  display: table;
+  content: "";
+}
+
+.d2-1405021153 .md hr::after {
+  display: table;
+  clear: both;
+  content: "";
+}
+
+.d2-1405021153 .md table {
+  border-spacing: 0;
+  border-collapse: collapse;
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow: auto;
+}
+
+.d2-1405021153 .md td,
+.d2-1405021153 .md th {
+  padding: 0;
+}
+
+.d2-1405021153 .md details summary {
+  cursor: pointer;
+}
+
+.d2-1405021153 .md details:not([open]) > *:not(summary) {
+  display: none !important;
+}
+
+.d2-1405021153 .md kbd {
+  display: inline-block;
+  padding: 3px 5px;
+  color: var(--color-fg-default);
+  vertical-align: middle;
+  background-color: var(--color-canvas-subtle);
+  border: solid 1px var(--color-neutral-muted);
+  border-bottom-color: var(--color-neutral-muted);
+  border-radius: 6px;
+  box-shadow: inset 0 -1px 0 var(--color-neutral-muted);
+}
+
+.d2-1405021153 .md h1,
+.d2-1405021153 .md h2,
+.d2-1405021153 .md h3,
+.d2-1405021153 .md h4,
+.d2-1405021153 .md h5,
+.d2-1405021153 .md h6 {
+  margin-top: 24px;
+  margin-bottom: 16px;
+  font-weight: 400;
+  line-height: 1.25;
+  font-family: "d2-1405021153-font-semibold";
+}
+
+.d2-1405021153 .md h2 {
+  padding-bottom: 0.3em;
+  font-size: 1.5em;
+  border-bottom: 1px solid var(--color-border-muted);
+}
+
+.d2-1405021153 .md h3 {
+  font-size: 1.25em;
+}
+
+.d2-1405021153 .md h4 {
+  font-size: 1em;
+}
+
+.d2-1405021153 .md h5 {
+  font-size: 0.875em;
+}
+
+.d2-1405021153 .md h6 {
+  font-size: 0.85em;
+  color: var(--color-fg-muted);
+}
+
+.d2-1405021153 .md p {
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+
+.d2-1405021153 .md blockquote {
+  margin: 0;
+  padding: 0 1em;
+  color: var(--color-fg-muted);
+  border-left: 0.25em solid var(--color-border-default);
+}
+
+.d2-1405021153 .md ul,
+.d2-1405021153 .md ol {
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-left: 2em;
+}
+
+.d2-1405021153 .md ol ol,
+.d2-1405021153 .md ul ol {
+  list-style-type: lower-roman;
+}
+
+.d2-1405021153 .md ul ul ol,
+.d2-1405021153 .md ul ol ol,
+.d2-1405021153 .md ol ul ol,
+.d2-1405021153 .md ol ol ol {
+  list-style-type: lower-alpha;
+}
+
+.d2-1405021153 .md dd {
+  margin-left: 0;
+}
+
+.d2-1405021153 .md pre {
+  margin-top: 0;
+  margin-bottom: 0;
+  word-wrap: normal;
+}
+
+.d2-1405021153 .md ::placeholder {
+  color: var(--color-fg-subtle);
+  opacity: 1;
+}
+
+.d2-1405021153 .md input::-webkit-outer-spin-button,
+.d2-1405021153 .md input::-webkit-inner-spin-button {
+  margin: 0;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.d2-1405021153 .md::before {
+  display: table;
+  content: "";
+}
+
+.d2-1405021153 .md::after {
+  display: table;
+  clear: both;
+  content: "";
+}
+
+.d2-1405021153 .md > *:first-child {
+  margin-top: 0 !important;
+}
+
+.d2-1405021153 .md > *:last-child {
+  margin-bottom: 0 !important;
+}
+
+.d2-1405021153 .md a:not([href]) {
+  color: inherit;
+  text-decoration: none;
+}
+
+.d2-1405021153 .md .absent {
+  color: var(--color-danger-fg);
+}
+
+.d2-1405021153 .md .anchor {
+  float: left;
+  padding-right: 4px;
+  margin-left: -20px;
+  line-height: 1;
+}
+
+.d2-1405021153 .md .anchor:focus {
+  outline: none;
+}
+
+.d2-1405021153 .md p,
+.d2-1405021153 .md blockquote,
+.d2-1405021153 .md ul,
+.d2-1405021153 .md ol,
+.d2-1405021153 .md dl,
+.d2-1405021153 .md table,
+.d2-1405021153 .md pre,
+.d2-1405021153 .md details {
+  margin-top: 0;
+  margin-bottom: 16px;
+}
+
+.d2-1405021153 .md blockquote > :first-child {
+  margin-top: 0;
+}
+
+.d2-1405021153 .md blockquote > :last-child {
+  margin-bottom: 0;
+}
+
+.d2-1405021153 .md sup > a::before {
+  content: "[";
+}
+
+.d2-1405021153 .md sup > a::after {
+  content: "]";
+}
+
+.d2-1405021153 .md h1:hover .anchor,
+.d2-1405021153 .md h2:hover .anchor,
+.d2-1405021153 .md h3:hover .anchor,
+.d2-1405021153 .md h4:hover .anchor,
+.d2-1405021153 .md h5:hover .anchor,
+.d2-1405021153 .md h6:hover .anchor {
+  text-decoration: none;
+}
+
+.d2-1405021153 .md h1 tt,
+.d2-1405021153 .md h1 code,
+.d2-1405021153 .md h2 tt,
+.d2-1405021153 .md h2 code,
+.d2-1405021153 .md h3 tt,
+.d2-1405021153 .md h3 code,
+.d2-1405021153 .md h4 tt,
+.d2-1405021153 .md h4 code,
+.d2-1405021153 .md h5 tt,
+.d2-1405021153 .md h5 code,
+.d2-1405021153 .md h6 tt,
+.d2-1405021153 .md h6 code {
+  padding: 0 0.2em;
+  font-size: inherit;
+}
+
+.d2-1405021153 .md ul.no-list,
+.d2-1405021153 .md ol.no-list {
+  padding: 0;
+  list-style-type: none;
+}
+
+.d2-1405021153 .md ol[type="1"] {
+  list-style-type: decimal;
+}
+
+.d2-1405021153 .md ol[type="a"] {
+  list-style-type: lower-alpha;
+}
+
+.d2-1405021153 .md ol[type="i"] {
+  list-style-type: lower-roman;
+}
+
+.d2-1405021153 .md div > ol:not([type]) {
+  list-style-type: decimal;
+}
+
+.d2-1405021153 .md ul ul,
+.d2-1405021153 .md ul ol,
+.d2-1405021153 .md ol ol,
+.d2-1405021153 .md ol ul {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.d2-1405021153 .md li > p {
+  margin-top: 16px;
+}
+
+.d2-1405021153 .md li + li {
+  margin-top: 0.25em;
+}
+
+.d2-1405021153 .md dl {
+  padding: 0;
+}
+
+.d2-1405021153 .md dl dt {
+  padding: 0;
+  margin-top: 16px;
+  font-size: 1em;
+  font-style: italic;
+  font-family: "d2-1405021153-font-semibold";
+}
+
+.d2-1405021153 .md dl dd {
+  padding: 0 16px;
+  margin-bottom: 16px;
+}
+
+.d2-1405021153 .md table th {
+  font-family: "d2-1405021153-font-semibold";
+}
+
+.d2-1405021153 .md table th,
+.d2-1405021153 .md table td {
+  padding: 6px 13px;
+  border: 1px solid var(--color-border-default);
+}
+
+.d2-1405021153 .md table tr {
+  background-color: var(--color-canvas-default);
+  border-top: 1px solid var(--color-border-muted);
+}
+
+.d2-1405021153 .md table tr:nth-child(2n) {
+  background-color: var(--color-canvas-subtle);
+}
+
+.d2-1405021153 .md table img {
+  background-color: transparent;
+}
+
+.d2-1405021153 .md img[align="right"] {
+  padding-left: 20px;
+}
+
+.d2-1405021153 .md img[align="left"] {
+  padding-right: 20px;
+}
+
+.d2-1405021153 .md span.frame {
+  display: block;
+  overflow: hidden;
+}
+
+.d2-1405021153 .md span.frame > span {
+  display: block;
+  float: left;
+  width: auto;
+  padding: 7px;
+  margin: 13px 0 0;
+  overflow: hidden;
+  border: 1px solid var(--color-border-default);
+}
+
+.d2-1405021153 .md span.frame span img {
+  display: block;
+  float: left;
+}
+
+.d2-1405021153 .md span.frame span span {
+  display: block;
+  padding: 5px 0 0;
+  clear: both;
+  color: var(--color-fg-default);
+}
+
+.d2-1405021153 .md span.align-center {
+  display: block;
+  overflow: hidden;
+  clear: both;
+}
+
+.d2-1405021153 .md span.align-center > span {
+  display: block;
+  margin: 13px auto 0;
+  overflow: hidden;
+  text-align: center;
+}
+
+.d2-1405021153 .md span.align-center span img {
+  margin: 0 auto;
+  text-align: center;
+}
+
+.d2-1405021153 .md span.align-right {
+  display: block;
+  overflow: hidden;
+  clear: both;
+}
+
+.d2-1405021153 .md span.align-right > span {
+  display: block;
+  margin: 13px 0 0;
+  overflow: hidden;
+  text-align: right;
+}
+
+.d2-1405021153 .md span.align-right span img {
+  margin: 0;
+  text-align: right;
+}
+
+.d2-1405021153 .md span.float-left {
+  display: block;
+  float: left;
+  margin-right: 13px;
+  overflow: hidden;
+}
+
+.d2-1405021153 .md span.float-left span {
+  margin: 13px 0 0;
+}
+
+.d2-1405021153 .md span.float-right {
+  display: block;
+  float: right;
+  margin-left: 13px;
+  overflow: hidden;
+}
+
+.d2-1405021153 .md span.float-right > span {
+  display: block;
+  margin: 13px auto 0;
+  overflow: hidden;
+  text-align: right;
+}
+
+.d2-1405021153 .md code,
+.d2-1405021153 .md tt {
+  padding: 0.2em 0.4em;
+  margin: 0;
+  font-size: 85%;
+  background-color: var(--color-neutral-muted);
+  border-radius: 6px;
+}
+
+.d2-1405021153 .md code br,
+.d2-1405021153 .md tt br {
+  display: none;
+}
+
+.d2-1405021153 .md del code {
+  text-decoration: inherit;
+}
+
+.d2-1405021153 .md pre code {
+  font-size: 100%;
+}
+
+.d2-1405021153 .md pre > code {
+  padding: 0;
+  margin: 0;
+  word-break: normal;
+  white-space: pre;
+  background: transparent;
+  border: 0;
+}
+
+.d2-1405021153 .md .highlight {
+  margin-bottom: 16px;
+}
+
+.d2-1405021153 .md .highlight pre {
+  margin-bottom: 0;
+  word-break: normal;
+}
+
+.d2-1405021153 .md .highlight pre,
+.d2-1405021153 .md pre {
+  padding: 16px;
+  overflow: auto;
+  font-size: 85%;
+  line-height: 1.45;
+  background-color: var(--color-canvas-subtle);
+  border-radius: 6px;
+}
+
+.d2-1405021153 .md pre code,
+.d2-1405021153 .md pre tt {
+  display: inline;
+  max-width: auto;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  line-height: inherit;
+  word-wrap: normal;
+  background-color: transparent;
+  border: 0;
+}
+
+.d2-1405021153 .md .csv-data td,
+.d2-1405021153 .md .csv-data th {
+  padding: 5px;
+  overflow: hidden;
+  font-size: 12px;
+  line-height: 1;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.d2-1405021153 .md .csv-data .blob-num {
+  padding: 10px 8px 9px;
+  text-align: right;
+  background: var(--color-canvas-default);
+  border: 0;
+}
+
+.d2-1405021153 .md .csv-data tr {
+  border-top: 0;
+}
+
+.d2-1405021153 .md .csv-data th {
+  font-family: "d2-1405021153-font-semibold";
+  background: var(--color-canvas-subtle);
+  border-top: 0;
+}
+
+.d2-1405021153 .md .footnotes {
+  font-size: 12px;
+  color: var(--color-fg-muted);
+  border-top: 1px solid var(--color-border-default);
+}
+
+.d2-1405021153 .md .footnotes ol {
+  padding-left: 16px;
+}
+
+.d2-1405021153 .md .footnotes li {
+  position: relative;
+}
+
+.d2-1405021153 .md .footnotes li:target::before {
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  bottom: -8px;
+  left: -24px;
+  pointer-events: none;
+  content: "";
+  border: 2px solid var(--color-accent-emphasis);
+  border-radius: 6px;
+}
+
+.d2-1405021153 .md .footnotes li:target {
+  color: var(--color-fg-default);
+}
+
+.d2-1405021153 .md .task-list-item {
+  list-style-type: none;
+}
+
+.d2-1405021153 .md .task-list-item label {
+  font-weight: 400;
+}
+
+.d2-1405021153 .md .task-list-item.enabled label {
+  cursor: pointer;
+}
+
+.d2-1405021153 .md .task-list-item + .task-list-item {
+  margin-top: 3px;
+}
+
+.d2-1405021153 .md .task-list-item .handle {
+  display: none;
+}
+
+.d2-1405021153 .md .task-list-item-checkbox {
+  margin: 0 0.2em 0.25em -1.6em;
+  vertical-align: middle;
+}
+
+.d2-1405021153 .md .contains-task-list:dir(rtl) .task-list-item-checkbox {
+  margin: 0 -1.6em 0.25em 0.2em;
+}
+</style><g class="bWFjaGluZQ=="><g class="shape" ><rect x="79.000000" y="76.000000" width="1253.000000" height="481.000000" rx="12.000000" stroke="#0D32B2" fill="#E3E9FD" class=" stroke-B2 fill-B4" style="stroke-width:2;stroke-dasharray:6.000000,5.919384;" /></g><text x="705.500000" y="63.000000" fill="#0A0F25" class="text fill-N1" style="text-anchor:middle;font-size:28px">Your machine (local-first)</text></g><g class="bGF3"><g class="shape" ></g><g><foreignObject requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" x="1764.000000" y="441.000000" width="341" height="24"><div xmlns="http://www.w3.org/1999/xhtml" class="md"><p><strong>Australian &amp; NZ primary law</strong>
+legislation · case law</p>
+</div></foreignObject></g></g><g class="bWFjaGluZS55b3U="><g class="shape" ></g><g><foreignObject requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" x="109.000000" y="441.000000" width="370" height="24"><div xmlns="http://www.w3.org/1999/xhtml" class="md"><p><strong>You / your AI assistant</strong>
+practitioner · researcher · agent</p>
+</div></foreignObject></g></g><g class="bWFjaGluZS5qdXJpc2Q="><g class="shape" ><rect x="831.000000" y="117.000000" width="471.000000" height="410.000000" rx="10.000000" stroke="#0D32B2" fill="#EDF0FD" class=" stroke-B1 fill-B5" style="stroke-width:2;" /></g><text x="1066.500000" y="105.000000" fill="#0A0F25" class="text fill-N1" style="text-anchor:middle;font-size:24px">jurisd (local-first legal workbench)</text></g><g class="bWFjaGluZS5qdXJpc2QubW9kdWxlcw=="><g class="shape" ><rect x="861.000000" y="147.000000" width="411.000000" height="82.000000" stroke="#0D32B2" fill="#F7F8FE" class=" stroke-B1 fill-B6" style="stroke-width:2;" /></g><text x="1066.500000" y="185.500000" fill="#0A0F25" class="text-bold fill-N1" style="text-anchor:middle;font-size:16px"><tspan x="1066.500000" dy="0.000000">Local data modules</tspan><tspan x="1066.500000" dy="18.500000">(provision lookup · citation graph · semantic search)</tspan></text></g><g class="bWFjaGluZS5qdXJpc2QubGl2ZQ=="><g class="shape" ><rect x="930.000000" y="289.000000" width="273.000000" height="82.000000" stroke="#0D32B2" fill="#F7F8FE" class=" stroke-B1 fill-B6" style="stroke-width:2;" /></g><text x="1066.500000" y="327.500000" fill="#0A0F25" class="text-bold fill-N1" style="text-anchor:middle;font-size:16px"><tspan x="1066.500000" dy="0.000000">Live research</tspan><tspan x="1066.500000" dy="18.500000">(AustLII + Exa-backed discovery)</tspan></text></g><g class="bWFjaGluZS5qdXJpc2QuY2l0ZQ=="><g class="shape" ><rect x="988.000000" y="431.000000" width="157.000000" height="66.000000" stroke="#0D32B2" fill="#F7F8FE" class=" stroke-B1 fill-B6" style="stroke-width:2;" /></g><text x="1066.500000" y="469.500000" fill="#0A0F25" class="text-bold fill-N1" style="text-anchor:middle;font-size:16px">AGLC4 citations</text></g><g class="bWFjaGluZS4oeW91IC0mZ3Q7IGp1cmlzZClbMF0="><marker id="mk-d2-1405021153-3488378134" markerWidth="10.000000" markerHeight="12.000000" refX="7.000000" refY="6.000000" viewBox="0.000000 0.000000 10.000000 12.000000" orient="auto" markerUnits="userSpaceOnUse"> <polygon points="0.000000,0.000000 10.000000,6.000000 0.000000,12.000000" fill="#0D32B2" class="connection fill-B1" stroke-width="2" /> </marker><path d="M 326.846811 440.037587 C 557.395020 352.149994 768.299988 330.000000 827.500000 330.000000" stroke="#0D32B2" fill="none" class="connection stroke-B1" style="stroke-width:2;" marker-end="url(#mk-d2-1405021153-3488378134)" mask="url(#d2-1405021153)" /><text x="570.500000" y="356.000000" fill="#676C7E" class="text-italic fill-N2" style="text-anchor:middle;font-size:16px">question</text></g><g class="KG1hY2hpbmUuanVyaXNkLmxpdmUgLSZndDsgbGF3KVswXQ=="><path d="M 1204.500000 330.000000 C 1344.900024 330.000000 1402.199951 330.000000 1434.750000 330.000000 C 1467.300049 330.000000 1682.078003 352.149994 1900.674239 439.269118" stroke="#0D32B2" fill="none" class="connection stroke-B1" style="stroke-width:2;" marker-end="url(#mk-d2-1405021153-3488378134)" mask="url(#d2-1405021153)" /><text x="1562.000000" y="345.000000" fill="#676C7E" class="text-italic fill-N2" style="text-anchor:middle;font-size:16px">retrieves</text></g><g class="KGxhdyAtJmd0OyBtYWNoaW5lLnlvdSlbMF0="><marker id="mk-d2-1405021153-164681321" markerWidth="13.000000" markerHeight="16.000000" refX="8.500000" refY="8.000000" viewBox="0.000000 0.000000 13.000000 16.000000" orient="auto" markerUnits="userSpaceOnUse"> <polygon points="0.000000,0.000000 13.000000,8.000000 0.000000,16.000000" fill="#0D32B2" class="connection fill-B1" stroke-width="3" /> </marker><path d="M 1900.180551 465.432822 C 1681.699951 553.299988 1599.000000 575.500000 1557.750000 575.500000 C 1516.500000 575.500000 1467.300049 575.500000 1434.750000 575.500000 C 1402.199951 575.500000 1317.699951 575.500000 1223.500000 575.500000 C 1129.300049 575.500000 1003.700012 575.500000 909.500000 575.500000 C 815.299988 575.500000 557.700012 553.299988 331.634316 466.472003" stroke="#0D32B2" fill="none" class="connection stroke-B1" style="stroke-width:3;" marker-end="url(#mk-d2-1405021153-164681321)" mask="url(#d2-1405021153)" /><text x="1115.500000" y="573.000000" fill="#676C7E" class="text-italic fill-N2" style="text-anchor:middle;font-size:16px"><tspan x="1115.500000" dy="0.000000">answer + verifiable citation</tspan><tspan x="1115.500000" dy="18.500000">to the primary source</tspan></text></g><mask id="d2-1405021153" maskUnits="userSpaceOnUse" x="-22" y="-65" width="2228" height="759">
+<rect x="-22" y="-65" width="2228" height="759" fill="white"></rect>
+<rect x="558.500000" y="35.000000" width="294" height="36" fill="rgba(0,0,0,0.75)"></rect>
+<rect x="1764.000000" y="441.000000" width="341" height="24" fill="rgba(0,0,0,0.75)"></rect>
+<rect x="109.000000" y="441.000000" width="370" height="24" fill="rgba(0,0,0,0.75)"></rect>
+<rect x="895.500000" y="81.000000" width="342" height="31" fill="rgba(0,0,0,0.75)"></rect>
+<rect x="883.500000" y="169.500000" width="366" height="37" fill="rgba(0,0,0,0.75)"></rect>
+<rect x="952.500000" y="311.500000" width="228" height="37" fill="rgba(0,0,0,0.75)"></rect>
+<rect x="1010.500000" y="453.500000" width="112" height="21" fill="rgba(0,0,0,0.75)"></rect>
+<rect x="542.000000" y="340.000000" width="57" height="21" fill="black"></rect>
+<rect x="1533.000000" y="329.000000" width="58" height="21" fill="black"></rect>
+<rect x="1027.000000" y="557.000000" width="177" height="37" fill="black"></rect>
+</mask></svg></svg>


### PR DESCRIPTION
Repositions the public docs around the provenance-first, local-first identity for a mixed audience, without leaking internal strategy. Docs only — no code or tool-surface changes.

## README
- **New identity up top** (replaces the dev-tool intro): source-grounded AU/NZ legal research on your own machine, every claim traceable to primary law. Guiding principle "no source span, no trusted legal claim."
- **Hero diagram** (`docs/diagrams/provenance-loop.{d2,svg}`, D2-rendered, committed source + SVG): the trust loop — your question → jurisd on your machine → AU/NZ primary law → answer with a verifiable citation back to the primary source. Neutral palette (no red/green) for accessibility.
- **"Why jurisd is different" / "Who it's for"**: framed by outcome and audience (practitioner, researcher/student, terminal-native power user, builder).
- **"Where this is heading"**: a capability-level, clearly future-tense roadmap (sandboxed local agent runtime, tamper-evident provenance + Evidence Pack, desktop app + TUI, SDK + plugins, connectors, source-anchored drafting). Nothing claimed as built.
- **Dropped "MCP server" from the identity** (the old `auslaw-mcp` framing); MCP stays in the setup section as the actual mechanism to connect it to your assistant, since that's what ships today.
- Old `auslaw-mcp` name noted once, discreetly, not in the tagline.

## ROADMAP
- Current state de-emphasises MCP-as-identity, records the Exa-backed AustLII discovery and the TUI search shell, and adds a "North star" section mirroring the README themes.

## IP safety
Scrubbed/withheld from public copy: the commercial substrate and entity, competitor teardown and pricing, security *architecture* internals, benchmark strategy, internal decision IDs, and certification roadmap. Public copy stays capability-level. Verified by a forbidden-term scan over the diff.

## Suggested GitHub About (≤350 chars), for you to set
> A local-first, provenance-first legal research workbench for Australia & New Zealand: every answer traces to primary law and your matter stays on your machine. Use it from the command line or from the AI assistant you already run: AustLII retrieval with Exa-backed search, deterministic provision lookup, offline citation graph, and AGLC4 linting.

## Notes
- Based on current `main` (v0.5.0): 12 tools, no jade, OALC + Exa fallback — the README reflects exactly that.
- Pre-existing em dashes in the unedited body were left as-is; new prose is em-dash-free.